### PR TITLE
edx-analytics-api-client is deprecated, and should be removed

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -105,9 +105,6 @@ edx/edx-analytics-dashboard:
 edx/edx-analytics-configuration:
     nick: acf
     track-pulls: true
-edx/edx-analytics-api-client:
-    nick: aap
-    track-pulls: true
 edx/edx-analytics-data-api-client:
     nick: aap
     track-pulls: true


### PR DESCRIPTION
@nedbat @sarina does this seem reasonable?