### PR TITLE
Bucketed per-month PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ auth.yaml
 db.url
 venv
 *.pyc
+*~
 
 age/age.json
 

--- a/helpers.py
+++ b/helpers.py
@@ -141,3 +141,77 @@ def only_once(func):
             func.only_once_return = ret
         return func.only_once_return
     return decorator
+
+
+def date_bucket_quarter(date):
+    """Compute the quarter for a date."""
+    date += datetime.timedelta(days=180)    # to almost get to our fiscal year
+    quarter = (date.month-1) // 3 + 1
+    return "Y{:02d} Q{}".format(date.year % 100, quarter)
+
+
+def date_bucket_month(date):
+    """Compute the year and month for a date."""
+    return "Y{:02d} M{:02d}".format(date.year % 100, date.month)
+
+
+def date_bucket_week(date):
+    """Compute the date of the Monday for a date, to bucket by weeks."""
+    monday = date - datetime.timedelta(days=date.weekday())
+    return "{:%Y-%m-%d}".format(monday)
+
+
+def lines_in_pull(pull):
+    """Return a line count for the pull request.
+
+    To consider both added and deleted, we add them together, but discount the
+    deleted count, on the theory that adding a line is harder than deleting a
+    line (*waves hands very broadly*).
+
+    """
+    ignore = r"(/vendor/)|(conf/locale)|(static/fonts)|(test/data/uploads)"
+    lines = 0
+    files = pull.get_files()
+    for f in files:
+        if re.search(ignore, f.filename):
+            #print("Ignoring file {}".format(f.filename))
+            continue
+        lines += f.additions + f.deletions//5
+    if pull.combinedstate == "merged" and lines > 2000:
+        print("*** Large pull: {lines:-6d} lines, {pr.created_at} {pr.number:-4d}: {pr.title}".format(lines=lines, pr=pull))
+    return lines
+
+
+def size_of_pull(pull):
+    """Return a size (small/large) for the pull.
+
+    This is based on a number of criteria, with wild-ass guesses about the
+    dividing line between large and small.  Don't read too much into this
+    distinction.
+
+    Returns "small" or "large".
+
+    """
+    limits = {
+        'pull.additions': 30,
+        'pull.changed_files': 5,
+        'pull.comments': 10,
+        'pull.commits': 3,
+        'pull.deletions': 30,
+        'pull.review_comments': 10,
+    }
+    for attr, limit in limits.iteritems():
+        if pull[attr] > limit:
+            return "large"
+    return "small"
+
+
+def print_repo_output(keys, buckets):
+    """
+    Given a list of dimension keys and the bucket data, print
+    it nicely to stdout (used in monthly_pr_stats and pull_quarters)
+    """
+    print("timespan\t" + "\t".join(keys))
+    for time_period in sorted(buckets.keys()):
+        data = buckets[time_period]
+        print("{}\t{}".format(time_period, "\t".join(str(data[k]) for k in keys)))

--- a/monthly_pr_stats.py
+++ b/monthly_pr_stats.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+"""
+Calculate pull requests opened and their current status by month.
+
+Returns the raw # of PRs opened, and their resultant state in a table:
+Month | #merged | #rejected | #unresolved | #opened |
+
+Note that this means the stats will change over time until all PRs are resolved.
+The sum of the first three data columns (#merged, #rejected, #unresolved) must equal
+the final column (#opened).
+"""
+
+from __future__ import print_function
+
+import argparse
+import collections
+import datetime
+import itertools
+import re
+import sys
+
+from helpers import date_arg, make_timezone_aware
+from repos import Repo
+
+
+def date_bucket_quarter(date):
+    """Compute the quarter for a date."""
+    date += datetime.timedelta(days=180)    # to almost get to our fiscal year
+    quarter = (date.month-1) // 3 + 1
+    return "Y{:02d} Q{}".format(date.year % 100, quarter)
+
+def date_bucket_month(date):
+    """Compute the year and month for a date."""
+    return "Y{:02d} M{:02d}".format(date.year % 100, date.month)
+
+def date_bucket_week(date):
+    """Compute the date of the Monday for a date, to bucket by weeks."""
+    monday = date - datetime.timedelta(days=date.weekday())
+    return "{:%Y-%m-%d}".format(monday)
+
+
+def get_all_repos(date_bucket_fn, start, lines=False, internal=False):
+    repos = [r for r in Repo.from_yaml() if r.track_pulls]
+
+    dimensions = [["merged", "closed", "unresolved", "opened"]]
+    if internal:
+        dimensions.append(["internal"])
+    else:
+        dimensions.append(["external"])
+
+    keys = [" ".join(prod) for prod in itertools.product(*dimensions)]
+    bucket_blank = dict.fromkeys(keys, 0)
+
+    buckets = collections.defaultdict(lambda: dict(bucket_blank))
+    for repo in repos:
+        get_bucket_data(buckets, repo.name, date_bucket_fn, start=start, lines=lines, internal=internal)
+
+    print("timespan\t" + "\t".join(keys))
+    for time_period in sorted(buckets.keys()):
+        data = buckets[time_period]
+        print("{}\t{}".format(time_period, "\t".join(str(data[k]) for k in keys)))
+
+
+def get_bucket_data(buckets, repo_name, date_bucket_fn, start, lines=False, internal=False):
+    print(repo_name)
+    pull_details = "all" if lines else "list"
+    for pull in get_pulls(repo_name, state="all", pull_details=pull_details, org=True):
+        # print("{0.id}: {0.combinedstate} {0.intext}".format(pull))
+
+        intext = pull.intext  # internal or external
+        # if internal is True, only want to look at "internal" PRs, and if
+        # internal is False, only want to look at "external" PRs.
+        if (internal and intext != 'internal') or (not internal and intext != 'external'):
+            continue
+
+        ignore_ref = "(^release$|^rc/)"
+        if re.search(ignore_ref, pull.base_ref):
+            # print("Ignoring pull #{0.number}: {0.title}".format(pull))
+            continue
+
+        if lines:
+            increment = lines_in_pull(pull)
+        else:
+            increment = 1
+
+        created = make_timezone_aware(pull.created_at)
+        bucket_key = date_bucket_fn(created)
+        if created >= start:
+            buckets[bucket_key]["opened " + intext] += increment
+
+            # Bucket based on its current state 
+            if pull.combinedstate == "merged":
+                buckets[bucket_key]["merged " + intext] += increment
+            elif pull.combinedstate == "closed":
+                buckets[bucket_key]["closed " + intext] += increment
+            else:
+                # PR is still open
+                buckets[bucket_key]["unresolved " + intext] += increment
+
+
+def lines_in_pull(pull):
+    """Return a line count for the pull request.
+
+    To consider both added and deleted, we add them together, but discount the
+    deleted count, on the theory that adding a line is harder than deleting a
+    line (*waves hands very broadly*).
+
+    """
+    ignore = r"(/vendor/)|(conf/locale)|(static/fonts)|(test/data/uploads)"
+    lines = 0
+    files = pull.get_files()
+    for f in files:
+        if re.search(ignore, f.filename):
+            #print("Ignoring file {}".format(f.filename))
+            continue
+        lines += f.additions + f.deletions//5
+    if pull.combinedstate == "merged" and lines > 2000:
+        print("*** Large pull: {lines:-6d} lines, {pr.created_at} {pr.number:-4d}: {pr.title}".format(lines=lines, pr=pull))
+    return lines
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Calculate external pull requests opened, and their current resolution status, by month.")
+    parser.add_argument(
+        "--quarterly", action="store_true",
+        help="Report on quarters instead of months"
+    )
+    parser.add_argument(
+        "--weekly", action="store_true",
+        help="Report on weeks instead of months"
+    )
+    parser.add_argument(
+        "--internal", action="store_true",
+        help="Report on internal, rather than external, prs."
+    )
+    parser.add_argument(
+        "--lines", action="store_true",
+        help="Count the number of lines changed instead of number of pull requests"
+    )
+    parser.add_argument(
+        "--start", type=date_arg,
+        help="Date to start collecting, format is flexible: "
+        "20141225, Dec/25/2014, 2014-12-25, etc"
+    )
+    parser.add_argument(
+        "--db", action="store_true",
+        help="Use WebhookDB instead of GitHub API"
+    )
+    args = parser.parse_args(argv[1:])
+
+    if args.quarterly:
+        date_bucket_fn = date_bucket_quarter
+    elif args.weekly:
+        date_bucket_fn = date_bucket_week
+    else:
+        date_bucket_fn = date_bucket_month
+
+    if args.start is None:
+        # Start keeping track Jun 1 2013 (when we became open source)
+        args.start = make_timezone_aware(datetime.datetime(2013, 6, 1))
+
+    global get_pulls
+    if args.db:
+        from webhookdb import get_pulls
+    else:
+        from githubapi import get_pulls
+
+    get_all_repos(date_bucket_fn, start=args.start, lines=args.lines, internal=args.internal)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/pull_quarters.py
+++ b/pull_quarters.py
@@ -17,24 +17,12 @@ import itertools
 import re
 import sys
 
-from helpers import date_arg, make_timezone_aware
+from helpers import (
+    date_bucket_quarter, date_bucket_month, date_bucket_week,
+    date_arg, make_timezone_aware, lines_in_pull, size_of_pull,
+    print_repo_output
+)
 from repos import Repo
-
-
-def date_bucket_quarter(date):
-    """Compute the quarter for a date."""
-    date += datetime.timedelta(days=180)    # to almost get to our fiscal year
-    quarter = (date.month-1) // 3 + 1
-    return "Y{:02d} Q{}".format(date.year % 100, quarter)
-
-def date_bucket_month(date):
-    """Compute the year and month for a date."""
-    return "Y{:02d} M{:02d}".format(date.year % 100, date.month)
-
-def date_bucket_week(date):
-    """Compute the date of the Monday for a date, to bucket by weeks."""
-    monday = date - datetime.timedelta(days=date.weekday())
-    return "{:%Y-%m-%d}".format(monday)
 
 
 def get_all_repos(date_bucket_fn, start, by_size=False, lines=False, closed=False):
@@ -56,10 +44,8 @@ def get_all_repos(date_bucket_fn, start, by_size=False, lines=False, closed=Fals
     for repo in repos:
         get_bucket_data(buckets, repo.name, date_bucket_fn, start=start, by_size=by_size, lines=lines, closed=closed)
 
-    print("timespan\t" + "\t".join(keys))
-    for time_period in sorted(buckets.keys()):
-        data = buckets[time_period]
-        print("{}\t{}".format(time_period, "\t".join(str(data[k]) for k in keys)))
+    print_repo_output(keys, buckets)
+
 
 def get_bucket_data(buckets, repo_name, date_bucket_fn, start, by_size=False, lines=False, closed=False):
     print(repo_name)
@@ -95,48 +81,6 @@ def get_bucket_data(buckets, repo_name, date_bucket_fn, start, by_size=False, li
             closed = make_timezone_aware(pull.closed_at)
             buckets[date_bucket_fn(closed)]["closed " + intext + size] += increment
 
-def size_of_pull(pull):
-    """Return a size (small/large) for the pull.
-
-    This is based on a number of criteria, with wild-ass guesses about the
-    dividing line between large and small.  Don't read too much into this
-    distinction.
-
-    Returns "small" or "large".
-
-    """
-    limits = {
-        'pull.additions': 30,
-        'pull.changed_files': 5,
-        'pull.comments': 10,
-        'pull.commits': 3,
-        'pull.deletions': 30,
-        'pull.review_comments': 10,
-    }
-    for attr, limit in limits.iteritems():
-        if pull[attr] > limit:
-            return "large"
-    return "small"
-
-def lines_in_pull(pull):
-    """Return a line count for the pull request.
-
-    To consider both added and deleted, we add them together, but discount the
-    deleted count, on the theory that adding a line is harder than deleting a
-    line (*waves hands very broadly*).
-
-    """
-    ignore = r"(/vendor/)|(conf/locale)|(static/fonts)|(test/data/uploads)"
-    lines = 0
-    files = pull.get_files()
-    for f in files:
-        if re.search(ignore, f.filename):
-            #print("Ignoring file {}".format(f.filename))
-            continue
-        lines += f.additions + f.deletions//5
-    if pull.combinedstate == "merged" and lines > 2000:
-        print("*** Large pull: {lines:-6d} lines, {pr.created_at} {pr.number:-4d}: {pr.title}".format(lines=lines, pr=pull))
-    return lines
 
 def main(argv):
     parser = argparse.ArgumentParser(description="Calculate internal & external pull requests, both opened & merged, by quarter.")

--- a/pull_quarters.py
+++ b/pull_quarters.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """
-Calculate pull requests opened and merged, by quarter.
+Calculate interal and external pull requests both opened and merged,
+by quarter, month, or week.
+
+Returns the raw # of PRs opened, and the raw # merged, per time increment.
+For example, if a PR is opened in July and merged in August, it is counted as
+opened in July, and merged in August.
 """
 
 from __future__ import print_function
@@ -134,7 +139,7 @@ def lines_in_pull(pull):
     return lines
 
 def main(argv):
-    parser = argparse.ArgumentParser(description="Summarize pull requests.")
+    parser = argparse.ArgumentParser(description="Calculate internal & external pull requests, both opened & merged, by quarter.")
     parser.add_argument(
         "--monthly", action="store_true",
         help="Report on months instead of quarters"


### PR DESCRIPTION
New script to calculate pull requests opened and their current status by month.

Returns the raw # of PRs opened, and their resultant state in a table:

Month | #merged | #rejected | #unresolved | #opened |

Note that this means the stats will change over time until all PRs are resolved. The sum of the first three data columns (#merged, #rejected, #unresolved) must equal the final column (#opened).

This data can be used to make cool graphs:
![screen shot 2015-04-22 at 1 50 31 pm](https://cloud.githubusercontent.com/assets/1985317/7281275/93e1c4b4-e8f6-11e4-9013-ac2f88247aeb.png)

![screen shot 2015-04-22 at 2 04 08 pm](https://cloud.githubusercontent.com/assets/1985317/7281585/78767614-e8f8-11e4-8a3d-9e702a827dba.png)

