### PR TITLE
Transition KPI: Scraping and parsing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv
 *~
 
 age/age.json
+states.json
 
 .sass-cache
 .webcache

--- a/jiraspider.py
+++ b/jiraspider.py
@@ -1,0 +1,48 @@
+import json
+
+from jira.client import JIRA
+
+import scrapy
+from scrapy.http import Request
+
+
+SERVER = 'https://openedx.atlassian.net'
+
+
+def jira_issue_keys(server_url, project_name):
+    """Get a list of JIRA issue keys for a project on a server."""
+    jira = JIRA({ 'server': server_url })
+    issues = jira.search_issues('project = {}'.format(project_name), maxResults=None)
+    return [iss.key for iss in issues]
+
+
+class IssueStateDurations(scrapy.Item):
+    issue = scrapy.Field()
+    states = scrapy.Field()
+
+
+class JiraSpider(scrapy.Spider):
+    name = 'jiraspider'
+
+    def start_requests(self):
+        keys = jira_issue_keys(SERVER, 'OSPR')
+        requests = []
+        for key in keys:
+            request = Request("{}/browse/{}?page=com.googlecode.jira-suite-utilities:transitions-summary-tabpanel".format(SERVER, key))
+            request.meta['issue_key'] = key
+            requests.append(request)
+
+        return requests
+
+    def parse(self, response):
+        item = IssueStateDurations()
+        item['issue'] = response.meta['issue_key']
+        item['states'] = states = {}
+
+        transitions = response.xpath('.//table[tr/th[text()="Time In Source Status"]]/tr[td]')
+        for trans in transitions:
+            source_status = trans.xpath('td[1]/table/tr/td[2]/text()').extract()[0].strip()
+            duration = trans.xpath('td[2]/text()').extract()[0].strip()
+            states[source_status] = duration
+
+        return item

--- a/jiraspider.py
+++ b/jiraspider.py
@@ -14,7 +14,11 @@ from jira.client import JIRA
 
 import scrapy
 from scrapy.http import Request
+from scrapy.conf import settings
 
+
+# Log only at INFO level -- change to 'DEBUG' for extremely verbose output.
+settings.set('LOG_LEVEL', 'INFO')
 
 SERVER = 'https://openedx.atlassian.net'
 
@@ -90,6 +94,9 @@ class IssueStateDurations(scrapy.Item):
     # the "Waiting on Author" state.
     resolution = scrapy.Field()
 
+    def __str__(self):
+        return "Processed issue {}".format(self.issue)
+
 
 class JiraSpider(scrapy.Spider):
     """Scrapy spider for scraping JIRA"""
@@ -161,7 +168,6 @@ class JiraSpider(scrapy.Spider):
         except ValueError:
             # couldn't parse the last execution time for some reason. Log error and continue.
             item['error'] += 'ERROR: failed to parse last execution date from date {date}\n'.format(
-                dest=dest_status,
                 date=trans_date
             )
             last_execution_date = None

--- a/jiraspider.py
+++ b/jiraspider.py
@@ -130,8 +130,7 @@ class JiraSpider(scrapy.Spider):
         transitions = response.xpath('.//table[tr/th[text()="Time In Source Status"]]/tr[td]')
         if not transitions:
             # Generally this means that the ticket is newly-opened
-            item['debug'] += "DEBUG: Could not find any transitions for key {}".format(item['issue'])
-            return item
+            item['debug'] += "DEBUG: Could not find any transitions for key {}. ".format(item['issue'])
 
         # Parse each transition, pulling out the source status & how much time was spent in that status
         for trans in self.clean_transitions(transitions, item):
@@ -143,7 +142,7 @@ class JiraSpider(scrapy.Spider):
             # ignore states that we spent less than one minute in (often this is just because transitioning
             # through JIRA states is stupid, or botbro is stupid)
             if source_status != 'Needs Triage' and duration_datetime < self.onemin:
-                item['debug'] += "Ignoring state ({}) of length {}".format(source_status, duration)
+                item['debug'] += "Ignoring state ({}) of length {}. ".format(source_status, duration)
                 continue
 
             # Add the amount of time spent in source status to any previous recorded time we've spent there
@@ -155,7 +154,6 @@ class JiraSpider(scrapy.Spider):
             )
 
         # Need to consider current state ('dest_status'), as well.
-
         # get "Last Execution Date" time -- in a terribly shitty format.
         trans_date = transitions[-1].xpath('td[5]/text()').extract()[0].strip()
         try:

--- a/jiraspider.py
+++ b/jiraspider.py
@@ -4,6 +4,7 @@ Spider to scrape JIRA for transitions in and out of states.
 Usage: `scrapy runspider jiraspider.py -o states.json`
 """
 from __future__ import print_function
+from collections import namedtuple
 
 import datetime
 import json
@@ -18,17 +19,33 @@ from scrapy.http import Request
 SERVER = 'https://openedx.atlassian.net'
 TIME_REGEX = re.compile(r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
 
+IssueFields = namedtuple('IssueFields', ['key', 'labels', 'issuetype'])
 
-def jira_issue_keys(server_url, project_name):
-    """Get a list of JIRA issue keys for a project on a server."""
+
+def extract_fields(issue):
+    key = issue.key
+    labels = issue.fields.labels
+    issuetype = issue.fields.issuetype.name
+    return IssueFields(key, labels, issuetype)
+
+
+def jira_issues(server_url, project_name):
+    """
+    Get JIRA issue keys for a project on a server.
+
+    Returns a list of IssueFields such as:
+    [IssueFields(key='OSPR-456', labels=['Dedx'], issuetype=u'Sub-task'),
+     IssueFields(key='OSPR-458', labels=[], issuetype=u'Pull Request Review')]
+    """
     jira = JIRA({ 'server': server_url })
     issues = jira.search_issues('project = {}'.format(project_name), maxResults=None)
-    return [iss.key for iss in issues]
+    return [extract_fields(iss) for iss in issues]
 
 
 class IssueStateDurations(scrapy.Item):
     issue = scrapy.Field()
     states = scrapy.Field()
+    labels = scrapy.Field()
 
 
 class JiraSpider(scrapy.Spider):
@@ -36,11 +53,15 @@ class JiraSpider(scrapy.Spider):
     default_time = datetime.timedelta(0)
 
     def start_requests(self):
-        keys = jira_issue_keys(SERVER, 'OSPR')
+        issues = jira_issues(SERVER, 'OSPR')
         requests = []
-        for key in keys:
-            request = Request("{}/browse/{}?page=com.googlecode.jira-suite-utilities:transitions-summary-tabpanel".format(SERVER, key))
-            request.meta['issue_key'] = key
+        for issue in issues:
+            # TODO (potentially) ignore subtasks, or do something with them? (issue.issuetype)
+            request = Request(
+                "{}/browse/{}?page=com.googlecode.jira-suite-utilities:transitions-summary-tabpanel".format(SERVER, issue.key)
+            )
+            request.meta['issue_key'] = issue.key
+            request.meta['labels'] = issue.labels
             requests.append(request)
 
         return requests
@@ -48,6 +69,7 @@ class JiraSpider(scrapy.Spider):
     def parse(self, response):
         item = IssueStateDurations()
         item['issue'] = response.meta['issue_key']
+        item['labels'] = response.meta['labels']
         states = {}
 
         transitions = response.xpath('.//table[tr/th[text()="Time In Source Status"]]/tr[td]')
@@ -65,8 +87,18 @@ class JiraSpider(scrapy.Spider):
                 return
 
         # TODO need to consider current state, unless in "merged" or "closed"
+        # we're in final state so get dest_status
+        dest_status = trans.xpath('td[1]/table/tr/td[5]/text()').extract()[0].strip()
+        if dest_status in ['Merged', 'Closed']:
+            # Store the resolution as a tuple of (source, result) so we can get not just resolution but previous state before resolution
+            states['Resolution'] = (source_status, dest_status)
+        else:
+            # get "Last Execution Date" time -- in a terribly shitty format.
+            trans_date = trans.xpath('td[5]/text()').extract()[0].strip()
+        #    current_duration = datetime.datetime.now() - self.parse_last_execution_time(trans_date)
+        #    states[dest_status] = states.get(dest_status, self.default_time) + current_duration
 
-        # json-serialize each timedelta ('xx:yy', xx days, yy seconds)
+        # json-serialize each timedelta ('xx:yy', xx days, yy seconds) (skipping useconds)
         item['states'] = {}
         for (state, tdelta) in states.iteritems():
             item['states'][state] = '{0.days}:{0.seconds}'.format(tdelta)
@@ -74,6 +106,13 @@ class JiraSpider(scrapy.Spider):
         return item
 
     def parse_time(self, duration):
+        """
+        Parses the duration time that we scrape from the "Time in Source Status" field.
+
+        Will be in one of 3 forms: "14d 22h 5m", "2h 33m", or "1m 10s".
+
+        We discard the seconds, and turn the d/h/m into a datetime.timedelta
+        """
         duration = duration.replace(' ', '')
         parts = TIME_REGEX.match(duration)
         td_dict = {}
@@ -82,3 +121,19 @@ class JiraSpider(scrapy.Spider):
                 td_dict[name] = int(value)
 
         return datetime.timedelta(**td_dict)
+
+    def parse_last_execution_time(self, etime):
+        """
+        parses the "last execution time" field in JIRA, which is a terrible format, either:
+        if over a week ago:
+        - 02/Apr/15 10:11 AM
+        if within the past week:
+        - Saturday 9:23 AM
+        if yesterday:
+        - Yesterday 11:05 AM
+        if today:
+        - Today 9:09 AM
+
+        Returns a datetime.datetime object representing whe the last execution time occured
+        """
+        raise NotImplementedError()

--- a/jiraspider.py
+++ b/jiraspider.py
@@ -1,4 +1,13 @@
+"""
+Spider to scrape JIRA for transitions in and out of states.
+
+Usage: `scrapy runspider jiraspider.py -o states.json`
+"""
+from __future__ import print_function
+
+import datetime
 import json
+import re
 
 from jira.client import JIRA
 
@@ -7,6 +16,7 @@ from scrapy.http import Request
 
 
 SERVER = 'https://openedx.atlassian.net'
+TIME_REGEX = re.compile(r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
 
 
 def jira_issue_keys(server_url, project_name):
@@ -23,6 +33,7 @@ class IssueStateDurations(scrapy.Item):
 
 class JiraSpider(scrapy.Spider):
     name = 'jiraspider'
+    default_time = datetime.timedelta(0)
 
     def start_requests(self):
         keys = jira_issue_keys(SERVER, 'OSPR')
@@ -37,12 +48,37 @@ class JiraSpider(scrapy.Spider):
     def parse(self, response):
         item = IssueStateDurations()
         item['issue'] = response.meta['issue_key']
-        item['states'] = states = {}
+        states = {}
 
         transitions = response.xpath('.//table[tr/th[text()="Time In Source Status"]]/tr[td]')
         for trans in transitions:
             source_status = trans.xpath('td[1]/table/tr/td[2]/text()').extract()[0].strip()
             duration = trans.xpath('td[2]/text()').extract()[0].strip()
-            states[source_status] = duration
+            # need to account for the fact that states can be revisited, along different transition arrow
+            duration_datetime = self.parse_time(duration)
+            try:
+                states[source_status] = states.get(source_status, self.default_time) + duration_datetime
+            except Exception:
+                src = states.get(source_status, self.default_time)
+                print('source status: {} {}'.format(src, type(src)))
+                print('duration: {} {}'.format(duration, type(duration)))
+                return
+
+        # TODO need to consider current state, unless in "merged" or "closed"
+
+        # json-serialize each timedelta ('xx:yy', xx days, yy seconds)
+        item['states'] = {}
+        for (state, tdelta) in states.iteritems():
+            item['states'][state] = '{0.days}:{0.seconds}'.format(tdelta)
 
         return item
+
+    def parse_time(self, duration):
+        duration = duration.replace(' ', '')
+        parts = TIME_REGEX.match(duration)
+        td_dict = {}
+        for (name, value) in parts.groupdict().iteritems():
+            if value:
+                td_dict[name] = int(value)
+
+        return datetime.timedelta(**td_dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ statistics
 uritemplate.py==0.2.0
 urlobject
 wsgiref==0.1.2
+jira
+scrapy
+

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -1,0 +1,37 @@
+"""
+Scrapes and parses information from JIRA's transition states.
+
+Runs the JIRA spider, then parses the output states.json
+file to obtain KPI information.
+"""
+from __future__ import print_function
+from subprocess import check_call
+
+import argparse
+import sys
+
+
+def scrape_jira():
+    check_call("scrapy runspider jiraspider.py -o states.json".split(" "))
+
+
+def parse_jira_info():
+    # Read in and parse states.json
+    raise NotImplementedError()
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Summarize JIRA info.")
+    parser.add_argument(
+        "--no-scrape", action="store_true",
+        help="Don't re-run the scraper, just read the current states.json file"
+    )
+    args = parser.parse_args(argv[1:])
+
+    if not args.no_scrape:
+        scrape_jira()
+
+    parse_jira_info()
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -164,10 +164,13 @@ def calculate_kpi(tickets, pretty=False, num_past_days=0):
             product_time += single_state_time_spent(ticket['states'], 'Product Review')
             product_tickets += 1
 
-    print_time_spent(triage_time_spent, num_tickets, 'Average time spent in Needs Triage', pretty)
-    print_time_spent(eng_time_spent, num_tickets, 'Average time spent in edX engineering states', pretty)
-    print_time_spent(backlog_time, backlog_tickets, 'Average time spent in team backlog', pretty)
-    print_time_spent(product_time, product_tickets, 'Average time spent in product review', pretty)
+    teng = print_time_spent(eng_time_spent, num_tickets, 'Average time spent in edX engineering states', pretty)
+    tnt = print_time_spent(triage_time_spent, num_tickets, 'Average time spent in Needs Triage', pretty)
+    tpr = print_time_spent(product_time, product_tickets, 'Average time spent in product review', pretty)
+    tap = print_time_spent(backlog_time, backlog_tickets, 'Average time spent in team backlog', pretty)
+    if not pretty:
+        print('Eng\t| Triage\t| Product\t| Backlog')
+        print('{}\t{}\t{}\t{}'.format(teng, tnt, tpr, tap))
 
 
 def print_time_spent(time_spent, ticket_count, message, pretty):
@@ -181,11 +184,11 @@ def print_time_spent(time_spent, ticket_count, message, pretty):
     days = avg_time.days
     hours, remainder = divmod(avg_time.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
-    print('\n' + message + ', over {} tickets'.format(ticket_count))
     if pretty:
+        print('\n' + message + ', over {} tickets'.format(ticket_count))
         print('\t {} days, {} hours, {} minutes, {} seconds'.format(days, hours, minutes, seconds))
     else:
-        print('\t {}:{}:{}:{}'.format(days, hours, minutes, seconds))
+        return '{}:{}:{}:{}'.format(days, hours, minutes, seconds)
 
 
 def main(argv):

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -1,23 +1,114 @@
+#!/usr/bin/env python
 """
 Scrapes and parses information from JIRA's transition states.
 
 Runs the JIRA spider, then parses the output states.json
 file to obtain KPI information.
+
+See https://openedx.atlassian.net/wiki/display/OPEN/Tracking+edX+Commitment+To+OSPRs
 """
 from __future__ import print_function
 from subprocess import check_call
 
 import argparse
+import datetime
+import json
 import sys
 
 
+EDX_ENGINEERING_STATES = [
+    'Needs Triage',
+    'Product Review',
+    'Community Manager Review',
+    'Awaiting Prioritization',
+    'Engineering Review',
+]
+
+
 def scrape_jira():
+    """
+    Re-scrapes jira into states.json
+    """
+    # Delete content of states.json before re-writing
+    with open("states.json", "w"):
+        pass
+
     check_call("scrapy runspider jiraspider.py -o states.json".split(" "))
 
 
-def parse_jira_info():
-    # Read in and parse states.json
-    raise NotImplementedError()
+def engineering_time_spent(state_dict):
+    """
+    Given a ticket's state dictionary, returns how much engineering time was spent on it.
+    Engineering states determined by EDX_ENGINEERING_STATES list.
+    """
+    # Measurement 1: Average Time Spent by edX Engineering
+    # This measurement will sum up the amount of time it takes the engineering team to process OSPR work.
+    # AverageTime = sum(amount of time a ticket spends in edX states) / count(all tickets)
+    # This will be a rolling average over all tickets currently open, or closed in the past X days.
+    # In the initial rollout of this measurement, we'll track for X=14, 30, and 60 days. After we have a few months'
+    # worth of data, we can assess what historical interval(s) gives us the most useful, actionable data.
+    # This is a measurement across all of engineering.  We are not proposing to measure teams individually.
+    total_time = datetime.timedelta(0)
+    for state, tdelta in state_dict.iteritems():
+        if state in EDX_ENGINEERING_STATES:
+            total_time += tdelta
+
+    return total_time
+
+
+def sanitize_ticket_states(state_dict):
+    """
+    Converts timedelta strings back into timedeltas.
+    These were explicitly serialized as '{0.days}:{0.seconds}'.format(tdelta)
+    """
+    result = {}
+    keys = ['days', 'seconds']
+    for state, tdelta in state_dict.iteritems():
+        tdelta = [int(x) for x in tdelta.split(':')]
+        tdict = {key: value for key, value in zip(keys, tdelta)}
+        result[state] = datetime.timedelta(**tdict)
+    return result
+
+
+def parse_jira_info(debug=False, pretty=False):
+    """
+    Read in and parse states.json
+    """
+    with open("states.json") as state_file:
+        # tickets is a list composed of state dictionaries for each ospr ticket.
+        # Keys are: 'issue' -> string, 'states' -> dict, 'labels' -> list,
+        # Optional keys are: 'resolution' -> list, 'debug' -> string, 'error' -> string
+        tickets = json.load(state_file)
+
+    eng_time_spent = datetime.timedelta(0)
+    num_tickets = 0
+    # TODO need to get when tickets were merged!
+    for ticket in tickets:
+        if ticket.get('error', False):
+            print("Error in ticket {}: {}".format(ticket['issue'], ticket['error']))
+        if debug and ticket.get('debug', False):
+            print("Debug: ticket {}: {}".format(ticket['issue'], ticket['debug']))
+
+        if ticket.get('states', False):
+            # Sanitize ticket state dict (need to convert time strings to timedeltas)
+            ticket['states'] = sanitize_ticket_states(ticket['states'])
+            # Calculate total time spent by engineering team on this ticket
+            eng_time_spent = engineering_time_spent(ticket['states'])
+            num_tickets += 1
+        elif debug or pretty:
+            print("No states yet for newly-opened ticket {}".format(ticket['issue']))
+
+    # Calculate average engineering time spent
+    avg_time = eng_time_spent / num_tickets
+    # Pretty print the average time
+    days = avg_time.days
+    hours, remainder = divmod(avg_time.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    print('\nAverage time spent in engineering review:')
+    if pretty:
+         print('\t {} days, {} hours, {} minutes, {} seconds'.format(days, hours, minutes, seconds))
+    else:
+        print('\t {}:{}:{}:{}'.format(days, hours, minutes, seconds))
 
 
 def main(argv):
@@ -26,12 +117,20 @@ def main(argv):
         "--no-scrape", action="store_true",
         help="Don't re-run the scraper, just read the current states.json file"
     )
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Show debugging messages"
+    )
+    parser.add_argument(
+        "--pretty", action="store_true",
+        help="Pretty print output"
+    )
     args = parser.parse_args(argv[1:])
 
     if not args.no_scrape:
         scrape_jira()
 
-    parse_jira_info()
+    parse_jira_info(args.debug, args.pretty)
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -34,7 +34,9 @@ def scrape_jira():
     with open("states.json", "w"):
         pass
 
+    print("Running scrapy spider over JIRA...")
     check_call("scrapy runspider jiraspider.py -o states.json".split(" "))
+    print("-" * 20)
 
 
 def engineering_time_spent(state_dict):
@@ -120,8 +122,7 @@ def parse_jira_info(debug=False, pretty=False):
 
         elif debug or pretty:
             print("No states yet for newly-opened ticket {}".format(ticket['issue']))
-        if ticket['issue'] == 'OSPR-566':
-            print('OSPR-565, states {}'.format(ticket['states']))
+
     return tickets
 
 
@@ -218,7 +219,7 @@ def main(argv):
 
     tickets = parse_jira_info(args.debug, args.pretty)
     calculate_kpi(tickets, args.pretty, args.since)
-    
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -62,10 +62,8 @@ def sanitize_ticket_states(state_dict):
     These were explicitly serialized as '{0.days}:{0.seconds}'.format(tdelta)
     """
     result = {}
-    keys = ['days', 'seconds']
     for state, tdelta in state_dict.iteritems():
-        tdelta = [int(x) for x in tdelta.split(':')]
-        tdict = {key: value for key, value in zip(keys, tdelta)}
+        tdict = {'days': tdelta[0], 'seconds': tdelta[1]}
         result[state] = datetime.timedelta(**tdict)
     return result
 
@@ -106,12 +104,13 @@ def parse_jira_info(debug=False, pretty=False):
     minutes, seconds = divmod(remainder, 60)
     print('\nAverage time spent in engineering review:')
     if pretty:
-         print('\t {} days, {} hours, {} minutes, {} seconds'.format(days, hours, minutes, seconds))
+        print('\t {} days, {} hours, {} minutes, {} seconds'.format(days, hours, minutes, seconds))
     else:
         print('\t {}:{}:{}:{}'.format(days, hours, minutes, seconds))
 
 
 def main(argv):
+    """a docstring for main, really?"""
     parser = argparse.ArgumentParser(description="Summarize JIRA info.")
     parser.add_argument(
         "--no-scrape", action="store_true",


### PR DESCRIPTION
We'll measure the time pull requests spend waiting for edX to do their work on them.  We'll track this to understand how responsive we are being to contributors' needs. Initial measurements will be across all of engineering, without individual team statistics.

https://openedx.atlassian.net/wiki/display/OPEN/Tracking+edX+Commitment+To+OSPRs