### PR TITLE
Transitions kpi refactoring

### DIFF
--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -175,7 +175,25 @@ def avg_time_spent(time_spent):
     """
     Returns the average time spent over the number of tickets.
     """
+    # Can't use numpy or other standards because sum() won't work with
+    # a list of datetime.timedeltas
     return reduce(operator.add, time_spent, datetime.timedelta(0)) / len(time_spent)
+
+
+def std_dev(time_spent):
+    """
+    Standard deviation of the list.
+
+    Calculation follows formula std = sqrt(mean( (x - x.mean())**2 ) )
+    """
+    avg = avg_time_spent(time_spent)
+    summation = 0
+    for sample in time_spent:
+        diff = sample - avg
+        summation += diff.total_seconds()**2
+    variance = summation / len(time_spent)
+    std = int(numpy.sqrt(variance))
+    return datetime.timedelta(seconds=std)
 
 
 def make_percentile(qper):
@@ -266,6 +284,10 @@ def main(argv):
         "--percentile", type=float,
         help="Print out the qth percentile of all tickets in each state"
     )
+    parser.add_argument(
+        "--std-dev", action="store_true",
+        help="Print out the standard deviation across the data"
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -284,6 +306,10 @@ def main(argv):
     if args.percentile:
         pfunc = make_percentile(args.percentile)
         get_stats(time_lists, pfunc, '{} Percentile'.format(args.percentile), args.pretty)
+        stats_printed = True
+
+    if args.std_dev:
+        get_stats(time_lists, std_dev, 'Std Deviation', args.pretty)
         stats_printed = True
 
     if args.average or not stats_printed:

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -171,22 +171,6 @@ def get_time_lists(tickets, num_past_days=0):
     return (eng_time_spent, triage_time_spent, product_time, backlog_time)
 
 
-# Time functions
-def median_time_spent(time_spent):
-    """
-    Returns the median time spent over the number of tickets.
-    """
-    sorted_time = sorted(time_spent)
-    lenlst = len(sorted_time)
-    index = (lenlst - 1) // 2
-
-    # Calculate median time spent
-    if lenlst % 2 == 1:
-        return sorted_time[index]
-
-    return (sorted_time[index] + sorted_time[index + 1]) / 2
-
-
 def avg_time_spent(time_spent):
     """
     Returns the average time spent over the number of tickets.
@@ -293,6 +277,7 @@ def main(argv):
     stats_printed = False
 
     if args.median:
+        median_time_spent = make_percentile(50)
         get_stats(time_lists, median_time_spent, 'Median', args.pretty)
         stats_printed = True
 

--- a/transitions_kpi.py
+++ b/transitions_kpi.py
@@ -288,6 +288,14 @@ def main(argv):
         "--std-dev", action="store_true",
         help="Print out the standard deviation across the data"
     )
+    parser.add_argument(
+        "--max", action="store_true",
+        help="Show the maximum time in the series"
+    )
+    parser.add_argument(
+        "--min", action="store_true",
+        help="Show the minimum time in the series"
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -310,6 +318,14 @@ def main(argv):
 
     if args.std_dev:
         get_stats(time_lists, std_dev, 'Std Deviation', args.pretty)
+        stats_printed = True
+
+    if args.max:
+        get_stats(time_lists, lambda lst: max(lst), 'Maximum', args.pretty)
+        stats_printed = True
+
+    if args.min:
+        get_stats(time_lists, lambda lst: min(lst), 'Minimum', args.pretty)
         stats_printed = True
 
     if args.average or not stats_printed:


### PR DESCRIPTION
Refactor Transitions KPI script to make it easy to add new statistical analysis.

Script reports average by default. Other statistics that can now be reported: percentile, median, max, min, and standard deviation.

```
$ python transitions_kpi.py -h
usage: transitions_kpi.py [-h] [--no-scrape] [--since DAYS] [--debug]
                          [--pretty] [--average] [--median]
                          [--percentile PERCENTILE] [--std-dev] [--max]
                          [--min]

Summarize JIRA info.

optional arguments:
  -h, --help            show this help message and exit
  --no-scrape           Don't re-run the scraper, just read the current
                        states.json file
  --since DAYS          Only consider unresolved PRs & PRs closed in the past
                        DAYS days
  --debug               Show debugging messages
  --pretty              Pretty print output
  --average             Print out the average time spent in each of 4 states
                        (this is the default action if none are selected)
  --median              Print out the median time spent in each of 4 states
  --percentile PERCENTILE
                        Print out the qth percentile of all tickets in each
                        state
  --std-dev             Print out the standard deviation across the data
  --max                 Show the maximum time in the series
  --min                 Show the minimum time in the series
```

Future refactoring will be to rejigger the printing mechanism. Right now, this is how things display:

```
$ python transitions_kpi.py --no-scrape --since=14 --max --min --average
Maximum time spent in each state
Eng	| Triage	| Product	| Backlog
220:23:17:9	5:22:6:0	48:21:30:3	187:5:20:20
Minimum time spent in each state
Eng	| Triage	| Product	| Backlog
0:0:0:17	0:0:0:0	0:4:26:0	0:0:1:46
Average time spent in each state
Eng	| Triage	| Product	| Backlog
27:22:33:52	0:18:47:39	10:7:48:47	35:6:10:8
```

I think for reporting, it will be better to have a spreadsheet with all interesting stats for a given state, eg
```
$ python transitions_kpi.py --no-scrape --since=14 --max --min --average
Engineering Backlog
Max | Min        | Average |
220:23:17:9	0:0:0:17	27:22:33:52	
Needs Triage
...
```

Then, the default is to print out all stats (max, min, avg, median, std dev) so we can track all those over time. Important to track all until we can figure out the best way to run this script over historical windows (right now, it just gives one point in time).