### PR TITLE
Add script to tag repos for Open edX releases

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-mock
+responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ urlobject
 wsgiref==0.1.2
 jira
 scrapy
-
+path.py
+gitpython

--- a/tag_release.py
+++ b/tag_release.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python
+"""
+Tag repos for an Open edX release. When run, this script will:
+
+1. Make sure we have an OAuth token for the GitHub API, and help the user
+   create one if we don't already have one
+2. Fetch the repos.yaml file from the repo-tools-data repo
+3. Identify the repos in that file that are tagged in the Open edX release
+4. Identify the commit that needs to be tagged in each repo, tracing cross-repo
+   dependencies as necessary
+5. Show the identified repos and commits, and ask for confirmation from the user
+6. Upon confirmation, create Git tags for the repos using the GitHub API
+"""
+from __future__ import unicode_literals, print_function
+import sys
+import re
+import json
+import getpass
+import argparse
+import logging
+try:
+    from path import Path as path
+    from git import Repo, Commit
+    from git.refs.symbolic import SymbolicReference
+    from git.exc import GitCommandError
+    import requests
+    from requests.exceptions import RequestException
+    import yaml
+except ImportError:
+    print("Error: missing dependencies! Please run this command to install them:")
+    print("pip install path.py requests GitPython PyYAML")
+    sys.exit(1)
+
+log = logging.getLogger(__name__)
+
+
+# Name used for fetching/storing GitHub OAuth tokens on disk
+TOKEN_NAME = "openedx-release"
+# URL to the source of truth about our repositories
+REPOS_YAML = "https://raw.githubusercontent.com/edx/repo-tools-data/master/repos.yaml"
+# Regular expression for parsing out the parts of a pip requirement line
+REQUIREMENT_RE = re.compile(r"""
+    git\+https?://github\.com/          # prefix
+    (?P<owner>[a-zA-Z0-9_.-]+)/         # repo owner
+    (?P<repo>[a-zA-Z0-9_.-]+).git       # repo name
+    (@(?P<ref>[a-zA-Z0-9_.-]+))?        # git ref (tag, branch, or commit hash) (optional)
+    (\#egg=(?P<egg>[a-zA-Z0-9_.-]+))?   # egg name (optional)
+    (==(?P<version>[a-zA-Z0-9_.-]+))?   # version (optional)
+""", re.VERBOSE)
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(
+        description="Tag GitHub repos for Open edX releases",
+    )
+    parser.add_argument(
+        'tag', metavar="TAGNAME",
+        help="The name of the tag to create in the repos",
+    )
+    parser.add_argument(
+        '-y', '--yes', action="store_false", default=True, dest="interactive",
+        help="non-interactive mode: answer yes to all questions",
+    )
+    parser.add_argument(
+        '-q', '--quiet', action="store_true", default=False,
+        help="don't print any unnecessary output"
+    )
+    parser.add_argument(
+        '-R', '--reverse', action="store_true", default=False,
+        help="delete tag instead of creating it"
+    )
+    parser.add_argument(
+        '--skip-invalid', action="store_true", default=False,
+        help="if the repos.yaml file points to an invalid repo, skip it "
+            "instead of throwing an error"
+    )
+    return parser
+
+
+def get_github_creds():
+    """
+    Returns GitHub credentials if they exist, as a two-tuple of (username, token).
+    Otherwise, return None.
+    """
+    netrc_auth = requests.utils.get_netrc_auth("https://api.github.com")
+    if netrc_auth:
+        return netrc_auth
+    config_file = (path("~/.config") / TOKEN_NAME).expand()
+    if config_file.isfile():
+        with open(config_file) as f:
+            config = json.load(f)
+        github_creds = config.get("credentials", {}).get("api.github.com", {})
+        username = github_creds.get("username", "")
+        token = github_creds.get("token", "")
+        if username and token:
+            return (username, token)
+    return None
+
+
+def create_github_creds():
+    """
+    https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+    """
+    headers = {"User-Agent": TOKEN_NAME}
+    payload = {
+        "note": TOKEN_NAME,
+        "scopes": ["repo"],
+    }
+    username = raw_input("GitHub username: ")
+    password = getpass.getpass("GitHub password: ")
+    response = requests.post(
+        "https://api.github.com/authorizations",
+        auth=(username, password),
+        headers=headers, json=payload,
+    )
+    # is the user using two-factor authentication?
+    otp_header = response.headers.get("X-GitHub-OTP")
+    if not response.ok and otp_header and otp_header.startswith("required;"):
+        # get two-factor code, redo the request
+        headers["X-GitHub-OTP"] = raw_input("Two-factor authentication code: ")
+        response = requests.post(
+            "https://api.github.com/authorizations",
+            auth=(username, password),
+            headers=headers, json=payload,
+        )
+    if not response.ok:
+        message = response.json()["message"]
+        if message != "Validation Failed":
+            raise requests.exceptions.RequestException(message)
+        else:
+            # A token with this TOKEN_NAME already exists on GitHub.
+            # Delete it, and try again.
+            token_id = get_github_auth_id(username, password, TOKEN_NAME)
+            if token_id:
+                delete_github_auth_token(username, password, token_id)
+            response = requests.post(
+                "https://api.github.com/authorizations",
+                auth=(username, password),
+                headers=headers, json=payload,
+            )
+    if not response.ok:
+        message = response.json()["message"]
+        raise requests.exceptions.RequestException(message)
+
+    return (username, response.json()["token"])
+
+
+def get_github_auth_id(username, password, note):
+    """
+    Return the ID associated with the GitHub auth token with the given note.
+    If no such auth token exists, return None.
+    """
+    response = requests.get(
+        "https://api.github.com/authorizations",
+        auth=(username, password),
+        headers={"User-Agent": TOKEN_NAME},
+    )
+    if not response.ok:
+        message = response.json()["message"]
+        raise requests.exceptions.RequestException(message)
+
+    for auth_token in response.json():
+        if auth_token["note"] == TOKEN_NAME:
+            return auth_token["id"]
+    return None
+
+
+def delete_github_auth_token(username, password, token_id):
+    response = requests.delete(
+        "https://api.github.com/authorizations/{id}".format(id=token_id),
+        auth=(username, password),
+        headers={"User-Agent": TOKEN_NAME},
+    )
+    if not response.ok:
+        message = response.json()["message"]
+        raise requests.exceptions.RequestException(message)
+
+
+def ensure_github_creds(attempts=3):
+    """
+    Make sure that we have GitHub OAuth credentials. This will check the user's
+    .netrc file, as well as the ~/.config/openedx-release file. If no credentials
+    exist in either place, it will prompt the user to create OAuth credentials,
+    and store them in ~/.config/openedx-release.
+
+    Returns False if we found credentials, True if we had to create them.
+    """
+    if get_github_creds():
+        return False
+
+    # Looks like we need to create the OAuth creds
+    print("We need to set up OAuth authentication with GitHub's API. "
+          "Your password will not be stored.", file=sys.stderr)
+    token = None
+    for _ in range(attempts):
+        try:
+            username, token = create_github_creds()
+        except requests.exceptions.RequestException as e:
+            print(
+                "Invalid authentication: {}".format(e.message),
+                file=sys.stderr,
+            )
+            continue
+        else:
+            break
+    if token:
+        print("Successfully authenticated to GitHub", file=sys.stderr)
+    if not token:
+        print("Too many invalid authentication attempts.", file=sys.stderr)
+        return False
+
+    config_file = (path("~/.config") / TOKEN_NAME).expand()
+    # make sure parent directory exists
+    config_file.parent.makedirs_p()
+    # read existing config if it exists
+    if config_file.isfile():
+        with open(config_file) as f:
+            config = json.load(f)
+    else:
+        config = {}
+    # update config
+    if 'credentials' not in config:
+        config["credentials"] = {}
+    if 'api.github.com' not in config['credentials']:
+        config["credentials"]["api.github.com"] = {}
+    config["credentials"]["api.github.com"]["username"] = username
+    config["credentials"]["api.github.com"]["token"] = token
+    # write it back out
+    with open(config_file, "w") as f:
+        json.dump(config, f)
+
+    return True
+
+
+def openedx_release_repos(session):
+    """
+    Return a subset of the repos listed in the repos.yaml file: the repos
+    with an `openedx-release` section.
+    """
+    repos_resp = session.get(REPOS_YAML)
+    repos_resp.raise_for_status()
+    all_repos = yaml.safe_load(repos_resp.text)
+    repos = {name: data for name, data in all_repos.items()
+             if data and data.get("openedx-release")}
+    return repos
+
+
+def commits_to_tag_in_repos(repos, session, skip_invalid=False):
+    """
+    Returns a dictionary of information about what commit should be tagged
+    for each repository passed into this function. The return type is as
+    follows:
+
+    {
+        "full_repo_name": {
+            "ref": "name of tag or branch"
+            "ref_type": "tag", # or "branch"
+            "sha": "1234566789abcdef",
+            "message": "The commit message"
+            "author": {
+                "name": "author's name",
+                "email": "author's email"
+            }
+            "committer": {
+                "name": "committer's name",
+                "email": "committer's email",
+            }
+        },
+        "next_repo_name": {...}
+    }
+
+    If the information in the passed-in dictionary is invalid in any way,
+    this function will throw an error unless `skip_invalid` is set to True,
+    in which case the invalid information will simply be logged and ignored.
+    """
+    to_tag = {}
+    for repo_name, repo_data in repos.items():
+        # make sure the repo exists
+        repo_url = "https://api.github.com/repos/{repo}".format(repo=repo_name)
+        repo_resp = session.get(repo_url)
+        if not repo_resp.ok:
+            msg = "Invalid repo {repo}".format(repo=repo_name)
+            if skip_invalid:
+                log.error(msg)
+                continue
+            else:
+                raise RuntimeError(msg)
+        # are we specifying a ref?
+        ref_name = repo_data["openedx-release"].get("ref")
+        if ref_name:
+            try:
+                to_tag[repo_name] = get_latest_commit_for_ref(
+                    repo_name,
+                    ref_name,
+                    session=session,
+                )
+            except RequestException, ValueError:
+                if skip_invalid:
+                    msg = "Invalid ref {ref} in repo {repo}".format(
+                        ref=ref_name,
+                        repo=repo_name,
+                    )
+                    log.error(msg)
+                    continue
+                else:
+                    raise
+        # are we specifying a parent repo?
+        parent_repo_name = repo_data["openedx-release"].get("parent-repo")
+        if parent_repo_name:
+            # we need the ref for the parent repo
+            parent_ref = repos[parent_repo_name]["openedx-release"]["ref"]
+            try:
+                to_tag[repo_name] = get_latest_commit_for_parent_repo(
+                    repo_name,
+                    parent_repo_name,
+                    parent_ref,
+                    session=session,
+                )
+            except RequestException, ValueError:
+                if skip_invalid:
+                    msg = "Problem getting parent ref for repo {repo}".format(
+                        repo=repo_name,
+                    )
+                    log.error(msg)
+                    continue
+                else:
+                    raise
+    return to_tag
+
+
+def get_latest_commit_for_ref(repo_name, ref, session):
+    """
+    Given a repo name and a ref in that repo, return some information about
+    the commit that the ref refers to. This function is called by
+    commits_to_tag_in_repos(), and it returns information in the same structure.
+    """
+    # is it a branch?
+    branch_url = "https://api.github.com/repos/{repo}/branches/{branch}".format(
+        repo=repo_name,
+        branch=ref,
+    )
+    branch_resp = session.get(branch_url)
+    if branch_resp.ok:
+        branch = branch_resp.json()
+        commit = branch["commit"]["commit"]
+        return {
+            "ref": ref,
+            "ref_type": "branch",
+            "sha": branch["commit"]["sha"],
+            "message": commit["message"],
+            "author": commit["author"],
+            "committer": commit["committer"],
+        }
+
+    if branch_resp.status_code != 404:
+        # This is not a simple "branch not found" error, it's something
+        # worse, like a 500 Server Error or a flaky network. Raise the error.
+        branch_resp.raise_for_status()
+
+    # is it a tag?
+    tag_url = "https://api.github.com/repos/{repo}/git/refs/tags/{tag}".format(
+        repo=repo_name,
+        tag=ref,
+    )
+    tag_resp = session.get(tag_url)
+    if tag_resp.ok:
+        tag = tag_resp.json()
+        # need to do a subsequent API call to get the tagged commit
+        commit_url = tag["object"]["url"]
+        commit_resp = session.get(commit_url)
+        if commit_resp.ok:
+            commit = commit_resp.json()
+            return {
+                "ref": ref,
+                "ref_type": "tag",
+                "sha": commit["sha"],
+                "message": commit["message"],
+                "author": commit["author"],
+                "committer": commit["committer"],
+            }
+
+    if tag_resp.status_code != 404:
+        # This is not a simple "tag not found" error, it's something
+        # worse, like a 500 Server Error or a flaky network. Raise the error.
+        tag_resp.raise_for_status()
+
+    msg = "No commit for {ref} in {repo}".format(
+        ref=ref, repo=repo_name,
+    )
+    raise ValueError(msg)
+
+
+def get_latest_commit_for_parent_repo(
+        repo_name, parent_repo_name, parent_ref, session,
+    ):
+    """
+    Some repos point to other repos via requirements files. For example,
+    edx/edx-platform points to edx/XBlock and edx/edx-ora2 via the github.txt
+    requirement file. This function takes two repo names: the target, and the
+    target's parent. (In this case, "edx/XBlock" could be the target, and
+    "edx/edx-platform" would be its parent.) This function looks up what
+    reference the parent uses to point at the target, and looks up the commit
+    that the reference points to in the target repo.
+
+    This function is called by commits_to_tag_in_repos(),
+    and it returns information in the same structure.
+    """
+    if parent_repo_name == "edx/edx-platform":
+        requirements_file = "requirements/edx/github.txt"
+    else:
+        requirements_file = "requirements.txt"
+
+    req_file_url = "https://raw.githubusercontent.com/{parent_repo}/{ref}/{req_file}".format(
+        parent_repo=parent_repo_name,
+        ref=parent_ref,
+        req_file=requirements_file,
+    )
+    req_file_resp = session.get(req_file_url)
+    req_file_resp.raise_for_status()
+    ref = get_ref_for_dependency(req_file_resp.text, repo_name, parent_repo_name)
+    return get_latest_commit_for_ref(repo_name, ref, session=session)
+
+
+def get_ref_for_dependency(requirements_text, repo_name, parent_repo_name=None):
+    requirements_lines = requirements_text.splitlines()
+    # strip lines that are empty, or start with comments
+    relevant_lines = [line for line in requirements_lines
+                      if line and not line.isspace() and not line.startswith("#")]
+
+    # find the line that corresponds to this repo
+    repo_lines = [line for line in relevant_lines if repo_name in line]
+    if not repo_lines:
+        msg = "{repo_name} dependency not found in {parent} repo".format(
+            repo_name=repo_name, parent=parent_repo_name,
+        )
+        raise ValueError(msg)
+    if len(repo_lines) > 1:
+        msg = "multiple {repo_name} dependencies found in {parent} repo".format(
+            repo_name=repo_name, parent=parent_repo_name,
+        )
+        raise ValueError(msg)
+
+    dependency_line = repo_lines[0]
+    # parse out the branch/tag
+    match = REQUIREMENT_RE.search(dependency_line)
+    if match:
+        ref = match.group('ref')
+    else:
+        ref = None
+    if not ref:
+        msg = "no reference found for {repo_name} dependency in {parent} repo".format(
+            repo_name=repo_name, parent=parent_repo_name,
+        )
+        raise ValueError(msg)
+    return ref
+
+
+def tag_exists_in_repo(tag, repo, session):
+    """
+    Returns a boolean indicating whether the given tag already exists in the
+    given repo.
+    """
+    tag_url = "https://api.github.com/repos/{repo}/git/refs/tags/{tag}".format(
+        repo=repo,
+        tag=tag,
+    )
+    tag_resp = session.get(tag_url)
+    return tag_resp.ok
+
+
+def repos_where_tag_exists(tag, repos, session):
+    return [repo for repo in repos if tag_exists_in_repo(tag, repo, session)]
+
+
+def todo_list(to_tag):
+    """
+    Returns a string, suitable to be printed on the command line,
+    that contains a record of the repos and commits that are about to be tagged.
+    If no tag info is passed in, return None.
+    """
+    if not to_tag:
+        return None
+
+    lines = []
+    for repo_name, commit_info in to_tag.items():
+        lines.append("{repo}: {ref} ({type}) {sha}".format(
+            repo=repo_name,
+            ref=commit_info['ref'],
+            type=commit_info['ref_type'],
+            sha=commit_info['sha'][0:7],
+        ))
+        lines.append("  " + commit_info["message"].splitlines()[0])
+    return "\n".join(lines)
+
+
+def tag_repos(to_tag, tag_name, session, rollback_on_fail=True):
+    """
+    Actually tag the repos with the given tag name.
+    If `rollback_on_fail` is True, then on any failure, try to delete the tags
+    that we're just created, so that we don't fail in a partially-completed
+    state. (Note that this is *not* a reliable rollback -- other people could
+    have already fetched the tags from GitHub, or the deletion attempt might
+    itself fail!)
+
+    If this function succeeds, it will return True. If this function fails,
+    but the world is in a consistent state, this function will return False.
+    The world is consistent if *no* repos were successfully tagged in the first
+    place, or all repos that were originally tagged were successfully rolled
+    back (because `rollback_on_fail` is set to True). If this function fails,
+    and the world is in an inconsistent state, this function will raise a
+    RuntimeError. This could happen if some (but not all) of the tags are created,
+    and either rollback is not attempted (because `rollback_on_fail` is set to
+    False), or rollback fails.
+    """
+    succeeded = []
+    failed_resp = None
+    failed_repo = None
+    ref_name = "refs/tags/{name}".format(name=tag_name)
+    for repo_name, commit_info in to_tag.items():
+        ref_url = "https://api.github.com/repos/{repo}/git/refs".format(repo=repo_name)
+        payload = {
+            "ref": ref_name,
+            "sha": commit_info['sha'],
+        }
+        resp = session.post(ref_url, json=payload)
+        if resp.ok:
+            succeeded.append(repo_name)
+        else:
+            failed_resp = resp
+            failed_repo = repo_name
+            # don't try to tag any others, just stop
+            break
+
+    if failed_resp is None:
+        return True
+
+    # if we got to this point, then there was a failure.
+    try:
+        original_err_msg = failed_resp.json()["message"]
+    except Exception:
+        original_err_msg = failed_resp.text
+
+    if not succeeded:
+        msg = (
+            "Failed to create {ref_name} on {failed_repo}. "
+            "Error was {orig_err}. No tags have been created on any repos."
+        ).format(
+            ref_name=ref_name,
+            failed_repo=failed_repo,
+            orig_err=original_err_msg,
+        )
+        log.error(msg)
+        return False
+
+    if rollback_on_fail:
+        rollback_failures = []
+        for repo_name in succeeded:
+            ref_url = "https://api.github.com/repos/{repo}/git/{ref_name}".format(
+                repo=repo_name,
+                ref_name=ref_name,
+            )
+            resp = session.delete(ref_url)
+            if not resp.ok:
+                rollback_failures.append(repo_name)
+
+        if rollback_failures:
+            msg = (
+                "Failed to create {ref_name} on {failed_repo}. "
+                "Error was {orig_err}. "
+                "Attempted to roll back, but failed to delete tag on "
+                "the following repos: {rollback_failures}"
+            ).format(
+                ref_name=ref_name,
+                failed_repo=failed_repo,
+                orig_err=original_err_msg,
+                rollback_failures=", ".join(rollback_failures)
+            )
+            err = RuntimeError(msg)
+            err.response = failed_resp
+            err.repos = rollback_failures
+            raise err
+        else:
+            msg = (
+                "Failed to create {ref_name} on {failed_repo}. "
+                "Error was {orig_err}. However, all refs were successfully "
+                "rolled back."
+            ).format(
+                ref_name=ref_name,
+                failed_repo=failed_repo,
+                orig_err=original_err_msg,
+            )
+            log.error(msg)
+            return False
+    else:
+        # don't try to rollback, just raise an error
+        msg = (
+            "Failed to create {ref_name} on {failed_repo}. "
+            "Error was {orig_err}. No rollback attempted. Tags exist on "
+            "the following repos: {tagged_repos}"
+        ).format(
+            ref_name=ref_name,
+            failed_repo=failed_repo,
+            orig_err=original_err_msg,
+            tagged_repos=", ".join(succeeded)
+        )
+        err = RuntimeError(msg)
+        err.response = failed_resp
+        err.repos = succeeded
+        raise err
+
+
+def untag_repos(repo_names, tag_name, session):
+    """
+    Given an iterable of repository full names (like "edx/edx-platform") and
+    a tag name, this function attempts to delete the named tag from each
+    GitHub repository listed in the iterable. If the tag does not exist on
+    the repo, it is skipped.
+
+    This function returns True if any repos were untagged, or False if no repos
+    were modified. If an error occurs while trying to untag a repo, the function
+    will continue trying to untag all the other repos in the iterable -- but
+    after all repos have been attempted, this function will raise a RuntimeError
+    with a list of all the repos that were not untagged. Trying to remove a tag
+    from a repo that does not have that tag to begin with is *not* treated as
+    an error.
+    """
+    failures = {}
+    modified = False
+    for repo_name in repo_names:
+        ref_url = "https://api.github.com/repos/{repo}/git/{ref_name}".format(
+            repo=repo_name,
+            ref_name="refs/tags/{tag}".format(tag=tag_name),
+        )
+        resp = session.delete(ref_url)
+        if resp.ok:
+            # successfully deleted -- we modified a repo
+            modified = True
+
+        elif resp.status_code == 422:
+            # error message: "Reference does not exist"
+            # tag didn't exist to begin with; not an error
+            pass
+
+        else:
+            # Oops, we got a failure. Record it and move on.
+            failures[repo_name] = resp
+
+    if failures:
+        msg = (
+            "Failed to untag the following repos: {repos}"
+        ).format(
+            repos=", ".join(failures.keys())
+        )
+        err = RuntimeError(msg)
+        err.failures = failures
+        raise err
+
+    return modified
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+
+    ensure_github_creds()
+    username, token = get_github_creds()
+    session = requests.Session()
+    session.headers["Authorization"] = "token {}".format(token)
+    session.headers["User-Agent"] = TOKEN_NAME
+
+    repos = openedx_release_repos(session)
+    if not repos:
+        raise ValueError("No repos marked for openedx-release in repos.yaml!")
+
+    if args.reverse:
+        modified = untag_repos(repos, args.tag, session)
+        if not args.quiet:
+            if modified:
+                print("{tag} tag removed from {repos}".format(
+                    tag=args.tag,
+                    repos=", ".join(repos.keys())
+                ))
+            else:
+                print("No tags modified")
+        return modified
+
+    already_exists = repos_where_tag_exists(args.tag, repos, session)
+    if already_exists:
+        msg = (
+            "The {tag} tag already exists in the following repos: {repos}"
+        ).format(
+            tag=args.tag,
+            repos=", ".join(already_exists),
+        )
+        raise ValueError(msg)
+
+    to_tag = commits_to_tag_in_repos(repos, session, skip_invalid=args.skip_invalid)
+    if args.interactive or not args.quiet:
+        print(todo_list(to_tag))
+    if args.interactive:
+        response = raw_input("Is this correct? [y/N] ")
+        if response.lower() not in ("y", "yes", "1"):
+            return
+
+    result = tag_repos(to_tag, args.tag, session)
+    if not args.quiet:
+        if result:
+            print("Success!")
+        else:
+            print("Failed to tag repos, but rolled back successfully")
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,216 @@
+import pytest
+import json
+import re
+import requests
+import textwrap
+import responses as resp_module
+
+
+@pytest.fixture
+def session():
+    return requests.Session()
+
+
+@pytest.fixture
+def responses(request):
+    resp_module.start()
+    def done():
+        resp_module.stop()
+        resp_module.reset()
+    request.addfinalizer(done)
+    return resp_module
+
+
+@pytest.fixture
+def common_mocks(mocker, responses):
+    mocker.patch("tag_release.get_github_creds", return_value=("user", "pass"))
+
+    fake_repos = textwrap.dedent("""
+        edx/edx-platform:
+            openedx-release:
+                ref: release
+        edx/configuration:
+            openedx-release:
+                ref: master
+        edx/XBlock:
+            openedx-release:
+                parent-repo: edx/edx-platform
+        edx/unrelated:
+            track-pulls: true
+    """)
+    responses.add(
+        responses.GET,
+        "https://raw.githubusercontent.com/edx/repo-tools-data/master/repos.yaml",
+        body=fake_repos,
+    )
+
+    repo_tags = {
+        "edx/edx-platform": {
+            "tag-exists-all-repos": "7878787",
+            "tag-exists-some-repos": "65656565",
+        },
+        "edx/configuration": {
+            "tag-exists-all-repos": "34233423"
+        },
+        "edx/XBlock": {
+            "tag-exists-all-repos": "987078987",
+            "0.4.4": "1a2b3c4d5e6f",
+        }
+    }
+    ref_url_re = re.compile(r"""
+        https://api\.github\.com/repos/
+        (?P<owner>[a-zA-Z0-9_.-]+)/
+        (?P<repo>[a-zA-Z0-9_.-]+)/
+        git/refs
+    """, re.VERBOSE)
+    tag_url_re = re.compile(r"""
+        https://api\.github\.com/repos/
+        (?P<owner>[a-zA-Z0-9_.-]+)/
+        (?P<repo>[a-zA-Z0-9_.-]+)/
+        git/refs/tags/
+        (?P<tag>[a-zA-Z0-9_./-]+)
+    """, re.VERBOSE)
+
+
+    def get_tag_callback(request):
+        match = tag_url_re.match(request.url)
+        tag = match.group('tag')
+        owner = match.group('owner')
+        repo = match.group('repo')
+        full_repo_name = "{owner}/{repo}".format(owner=owner, repo=repo)
+        sha = repo_tags.get(full_repo_name, {}).get(tag, "")
+        if sha:
+            commit_url = "https://api.github.com/repos/{owner}/{repo}/git/commits/{sha}".format(
+                owner=owner,
+                repo=repo,
+                sha=sha
+            )
+            ret_payload = {
+                "ref": "refs/tags/{tag}".format(tag=tag),
+                "object": {
+                    "type": "commit",
+                    "url": commit_url,
+                }
+            }
+            return 200, {"Content-Type": "application/json"}, json.dumps(ret_payload)
+        else:
+            return 404, {}, ''
+
+    responses.add_callback(
+        responses.GET, tag_url_re, callback=get_tag_callback,
+    )
+
+    def create_tag_callback(request):
+        match = ref_url_re.match(request.url)
+        owner = match.group('owner')
+        repo = match.group('repo')
+        full_repo_name = "{owner}/{repo}".format(owner=owner, repo=repo)
+        payload = json.loads(request.body)
+        ref = payload["ref"]
+        assert ref.startswith("refs/tags/")
+        tag = ref[10:]
+        if tag not in repo_tags.get(full_repo_name, {}):
+            # create the tag
+            sha = payload["sha"]
+            repo_tags[full_repo_name][tag] = sha
+            tag_url = "https://api.github.com/repos/{full_repo}/git/refs/tags/{tag}".format(
+                full_repo=full_repo_name,
+                tag=tag,
+            )
+            ret_payload = {
+                "ref": "refs/tags/{tag}".format(tag=tag),
+                "url": tag_url,
+                "object": {
+                    "sha": sha,
+                    "type": "commit"
+                }
+            }
+            headers = {
+                "Location": tag_url,
+                "Content-Type": "application/json",
+            }
+            return 201, headers, json.dumps(ret_payload)
+        else:
+            # tag already exists
+            return 422, {"Content-Type": "application/json"}, json.dumps({"message": "Reference already exists"})
+
+    responses.add_callback(
+        responses.POST, ref_url_re, callback=create_tag_callback,
+    )
+
+    def delete_tag_callback(request):
+        match = tag_url_re.match(request.url)
+        tag = match.group('tag')
+        owner = match.group('owner')
+        repo = match.group('repo')
+        full_repo_name = "{owner}/{repo}".format(owner=owner, repo=repo)
+        if tag in repo_tags.get(full_repo_name, {}):
+            del repo_tags[full_repo_name][tag]
+            return 204, {}, ''
+        else:
+            return 422, {"Content-Type": "application/json"}, json.dumps({"message": "Reference does not exist"})
+
+    responses.add_callback(
+        responses.DELETE, tag_url_re, callback=delete_tag_callback,
+    )
+
+    repo_url_tpl = "https://api.github.com/repos/{full_repo}"
+    for repo_name in repo_tags:
+        responses.add(responses.GET, repo_url_tpl.format(full_repo=repo_name), status=200)
+
+    platform_release_branch = {
+        "name": "release",
+        "commit": {
+            "sha": "deadbeef12345",
+            "commit": {
+                "author": {
+                    "name": "Dev 1"
+                },
+                "committer": {
+                    "name": "Dev 1",
+                },
+                "message": "commit message for edx-platform release commit"
+            }
+        }
+    }
+    branch_url = "https://api.github.com/repos/edx/edx-platform/branches/release"
+    responses.add(responses.GET, branch_url, json=platform_release_branch)
+
+    configuration_master_branch = {
+        "name": "master",
+        "commit": {
+            "sha": "12345deadbeef",
+            "commit": {
+                "author": {
+                    "name": "Dev 2"
+                },
+                "committer": {
+                    "name": "Dev 2",
+                },
+                "message": "commit message for configuration master commit"
+            }
+        }
+    }
+    branch_url = "https://api.github.com/repos/edx/configuration/branches/master"
+    responses.add(responses.GET, branch_url, json=configuration_master_branch)
+
+    github_txt = textwrap.dedent("""
+        git+https://github.com/edx/XBlock.git@0.4.4#egg=XBlock==0.4.4
+    """)
+    github_txt_url = "https://raw.githubusercontent.com/edx/edx-platform/release/requirements/edx/github.txt"
+    responses.add(responses.GET, github_txt_url, body=github_txt)
+
+    xblock_tag_commit_url = "https://api.github.com/repos/edx/XBlock/git/commits/1a2b3c4d5e6f"
+    xblock_tag_commit = {
+        "sha": "1a2b3c4d5e6f",
+        "author": {
+            "name": "Dev 3"
+        },
+        "committer": {
+            "name": "Dev 3",
+        },
+        "message": "commit message for XBlock at 0.4.4 tag",
+    }
+    xblock_branch_url = "https://api.github.com/repos/edx/XBlock/branches/0.4.4"
+    responses.add(responses.GET, xblock_branch_url, status=404)
+    responses.add(responses.GET, xblock_tag_commit_url, json=xblock_tag_commit)

--- a/tests/test_tag_release.py
+++ b/tests/test_tag_release.py
@@ -1,0 +1,328 @@
+import pytest
+import json
+import requests
+from collections import OrderedDict
+from tag_release import (
+    openedx_release_repos, repos_where_tag_exists, commits_to_tag_in_repos,
+    tag_repos, untag_repos,
+)
+
+pytestmark = pytest.mark.usefixtures("common_mocks")
+
+
+expected_repos = {
+    'edx/edx-platform': {
+        'openedx-release': {
+            'ref': 'release',
+        }
+    },
+    'edx/configuration': {
+        'openedx-release': {
+            'ref': 'master',
+        }
+    },
+    'edx/XBlock': {
+        'openedx-release': {
+            'parent-repo': 'edx/edx-platform',
+        }
+    },
+}
+
+expected_commits = {
+    'edx/edx-platform': {
+        'committer': {'name': 'Dev 1'},
+        'author': {'name': 'Dev 1'},
+        'sha': 'deadbeef12345',
+        'ref_type': 'branch',
+        'ref': 'release',
+        'message': 'commit message for edx-platform release commit',
+    },
+    'edx/configuration': {
+        'committer': {'name': 'Dev 2'},
+        'author': {'name': 'Dev 2'},
+        'sha': '12345deadbeef',
+        'ref_type': 'branch',
+        'ref': 'master',
+        'message': 'commit message for configuration master commit',
+    },
+    'edx/XBlock': {
+        'committer': {'name': 'Dev 3'},
+        'author': {'name': 'Dev 3'},
+        'sha': '1a2b3c4d5e6f',
+        'ref_type': 'tag',
+        'ref': '0.4.4',
+        'message': 'commit message for XBlock at 0.4.4 tag',
+    }
+}
+
+
+def test_get_repos(session):
+    repos = openedx_release_repos(session)
+    assert repos == expected_repos
+
+
+def test_repos_where_tag_exists(session):
+    result = repos_where_tag_exists("tag-exists-some-repos", expected_repos, session)
+    assert result == ["edx/edx-platform"]
+
+
+def test_repos_where_tag_does_not_exist(session):
+    result = repos_where_tag_exists("tag-exists-no-repos", expected_repos, session)
+    assert result == []
+
+
+def test_commits_to_tag(session):
+    result = commits_to_tag_in_repos(expected_repos, session)
+    assert result == expected_commits
+
+
+def test_tag_repos_happy_path(session, responses):
+    # creating a tag that does not already exist anywhere
+    result = tag_repos(
+        expected_commits,
+        "tag-exists-no-repos",
+        session,
+    )
+    assert result is True
+    assert len(responses.calls) == 3
+    # calls could be made in any order
+    platform_url = "https://api.github.com/repos/edx/edx-platform/git/refs"
+    platform_call = [call for call in responses.calls if call.request.url == platform_url][0]
+    assert platform_call.request.method == "POST"
+    assert json.loads(platform_call.request.body) == {
+        "sha": "deadbeef12345",
+        "ref": "refs/tags/tag-exists-no-repos",
+    }
+    configuration_url = "https://api.github.com/repos/edx/configuration/git/refs"
+    configuration_call = [call for call in responses.calls if call.request.url == configuration_url][0]
+    assert configuration_call.request.method == "POST"
+    assert json.loads(configuration_call.request.body) == {
+        "sha": "12345deadbeef",
+        "ref": "refs/tags/tag-exists-no-repos",
+    }
+    xblock_url = "https://api.github.com/repos/edx/XBlock/git/refs"
+    xblock_call = [call for call in responses.calls if call.request.url == xblock_url][0]
+    assert xblock_call.request.method == "POST"
+    assert json.loads(xblock_call.request.body) == {
+        "sha": "1a2b3c4d5e6f",
+        "ref": "refs/tags/tag-exists-no-repos",
+    }
+
+
+def test_tag_repos_existing_tag(session, responses):
+    # creating a tag that already exists in edx-platform: we'll make sure
+    # that edx-platform is attempted *first*
+    ordered_commits = OrderedDict(
+        sorted(expected_commits.items(), key=lambda x: x[0], reverse=True)
+    )
+    result = tag_repos(
+        ordered_commits,
+        "tag-exists-some-repos",
+        session,
+    )
+    assert result is False
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs"
+    payload = json.loads(responses.calls[0].request.body)
+    assert payload == {
+        "sha": "deadbeef12345",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+
+def test_tag_repos_existing_tag_at_end(session, responses):
+    # creating a tag that already exists in edx-platform: we'll make sure
+    # that edx-platform is attempted *last*
+    ordered_commits = OrderedDict(
+        sorted(expected_commits.items(), key=lambda x: x[0], reverse=False)
+    )
+    result = tag_repos(
+        ordered_commits,
+        "tag-exists-some-repos",
+        session,
+    )
+    assert result is False
+    assert len(responses.calls) == 5
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/XBlock/git/refs"
+    xb_payload = json.loads(responses.calls[0].request.body)
+    assert xb_payload == {
+        "sha": "1a2b3c4d5e6f",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs"
+    conf_payload = json.loads(responses.calls[1].request.body)
+    assert conf_payload == {
+        "sha": "12345deadbeef",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs"
+    plat_payload = json.loads(responses.calls[2].request.body)
+    assert plat_payload == {
+        "sha": "deadbeef12345",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    # third request failed, so rollback the other two
+    assert responses.calls[3].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[3].request.method == 'DELETE'
+    assert responses.calls[4].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[4].request.method == 'DELETE'
+
+
+def test_tag_repos_existing_tag_at_end_no_rollback(session, responses):
+    # creating a tag that already exists in edx-platform: we'll make sure
+    # that edx-platform is attempted *last*
+    ordered_commits = OrderedDict(
+        sorted(expected_commits.items(), key=lambda x: x[0], reverse=False)
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        tag_repos(
+            ordered_commits,
+            "tag-exists-some-repos",
+            session,
+            rollback_on_fail=False
+        )
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/XBlock/git/refs"
+    xb_payload = json.loads(responses.calls[0].request.body)
+    assert xb_payload == {
+        "sha": "1a2b3c4d5e6f",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs"
+    conf_payload = json.loads(responses.calls[1].request.body)
+    assert conf_payload == {
+        "sha": "12345deadbeef",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs"
+    plat_payload = json.loads(responses.calls[2].request.body)
+    assert plat_payload == {
+        "sha": "deadbeef12345",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert "No rollback attempted" in str(excinfo.value)
+    assert "Reference already exists" in str(excinfo.value)
+    assert "Tags exist on the following repos: edx/XBlock, edx/configuration" in str(excinfo.value)
+
+
+def test_tag_repos_existing_tag_at_end_rollback_failure(session, responses):
+    # creating a tag that already exists in edx-platform: we'll make sure
+    # that edx-platform is attempted *last*
+    ordered_commits = OrderedDict(
+        sorted(expected_commits.items(), key=lambda x: x[0], reverse=False)
+    )
+
+    # when we try to delete the configuration tag, it will fail with a 500 error
+    responses.add(
+        responses.DELETE,
+        "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-some-repos",
+        status=500,
+    )
+
+    ### DANGER: ACCESSING PRIVATE APIS FOR RESPONSES LIBRARY ###
+    # grab the object we just created
+    last_responses_url_obj = responses._default_mock._urls[-1]
+    # move it to the front, so it matches *first*
+    responses._default_mock._urls.insert(0, last_responses_url_obj)
+    ### END PRIVATE API ACCESS FOR RESPONSES LIBRARY ###
+
+    with pytest.raises(RuntimeError) as excinfo:
+        tag_repos(
+            ordered_commits,
+            "tag-exists-some-repos",
+            session,
+        )
+    assert len(responses.calls) == 5
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/XBlock/git/refs"
+    xb_payload = json.loads(responses.calls[0].request.body)
+    assert xb_payload == {
+        "sha": "1a2b3c4d5e6f",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs"
+    conf_payload = json.loads(responses.calls[1].request.body)
+    assert conf_payload == {
+        "sha": "12345deadbeef",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs"
+    plat_payload = json.loads(responses.calls[2].request.body)
+    assert plat_payload == {
+        "sha": "deadbeef12345",
+        "ref": "refs/tags/tag-exists-some-repos",
+    }
+    # third response failed, so try to rollback. XBlock succeeds...
+    assert responses.calls[3].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[3].request.method == 'DELETE'
+    assert responses.calls[4].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[4].request.method == 'DELETE'
+    # ... but configuration fails, so we get an exception
+    assert "failed to delete tag on the following repos: edx/configuration" in str(excinfo)
+
+
+def test_untag_repos_all(session, responses):
+    repo_names = ["edx/edx-platform", "edx/configuration", "edx/XBlock"]
+    result = untag_repos(repo_names, "tag-exists-all-repos", session)
+    assert result is True
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[0].request.method == "DELETE"
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[1].request.method == "DELETE"
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[2].request.method == "DELETE"
+
+
+def test_untag_repos_some(session, responses):
+    repo_names = ["edx/edx-platform", "edx/configuration", "edx/XBlock"]
+    result = untag_repos(repo_names, "tag-exists-some-repos", session)
+    assert result is True
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[0].request.method == "DELETE"
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[1].request.method == "DELETE"
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-some-repos"
+    assert responses.calls[2].request.method == "DELETE"
+
+
+def test_untag_repos_none(session, responses):
+    repo_names = ["edx/edx-platform", "edx/configuration", "edx/XBlock"]
+    result = untag_repos(repo_names, "tag-exists-no-repos", session)
+    assert result is False
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs/tags/tag-exists-no-repos"
+    assert responses.calls[0].request.method == "DELETE"
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-no-repos"
+    assert responses.calls[1].request.method == "DELETE"
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-no-repos"
+    assert responses.calls[2].request.method == "DELETE"
+
+
+def test_untag_repos_with_errors(session, responses):
+    repo_names = ["edx/edx-platform", "edx/configuration", "edx/XBlock"]
+
+    # when we try to delete the edx-platform tag, it will fail with a 500 error
+    responses.add(
+        responses.DELETE,
+        "https://api.github.com/repos/edx/edx-platform/git/refs/tags/tag-exists-all-repos",
+        status=500,
+    )
+
+    ### DANGER: ACCESSING PRIVATE APIS FOR RESPONSES LIBRARY ###
+    # grab the object we just created
+    last_responses_url_obj = responses._default_mock._urls[-1]
+    # move it to the front, so it matches *first*
+    responses._default_mock._urls.insert(0, last_responses_url_obj)
+    ### END PRIVATE API ACCESS FOR RESPONSES LIBRARY ###
+
+    with pytest.raises(RuntimeError) as excinfo:
+        untag_repos(repo_names, "tag-exists-all-repos", session)
+
+    assert len(responses.calls) == 3
+    assert responses.calls[0].request.url == "https://api.github.com/repos/edx/edx-platform/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[0].request.method == "DELETE"
+    assert responses.calls[1].request.url == "https://api.github.com/repos/edx/configuration/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[1].request.method == "DELETE"
+    assert responses.calls[2].request.url == "https://api.github.com/repos/edx/XBlock/git/refs/tags/tag-exists-all-repos"
+    assert responses.calls[2].request.method == "DELETE"
+    assert "Failed to untag the following repos: edx/edx-platform" in str(excinfo)


### PR DESCRIPTION
This `tag_release.py` script will tag repositories for Open edX releases. It accepts one argument, the name of the tag to create. It determines which commits need to be tagged in which repos, and asks for confirmation. Then it uses the GitHub API to create tags on all the repos. There are also automated tests to cover the most important functionality of the script.

Relies on https://github.com/edx/repo-tools-data/pull/5