### PR TITLE
Fix --dry and --yes

### DIFF
--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -568,7 +568,7 @@ def remove_ref_for_repos(repos, ref, use_tag=True, dry=True):
          u"This option can be provided multiple times."
 )
 @click.option(
-    '-y', '--yes', 'interactive', is_flag=True, default=True,
+    '-y', '--yes', 'interactive', is_flag=True, default=True, flag_value=False,
     help=u"non-interactive mode: answer yes to all questions"
 )
 @click.option(

--- a/edx_repo_tools/utils.py
+++ b/edx_repo_tools/utils.py
@@ -23,15 +23,14 @@ def dry_echo(dry, message, *args, **kwargs):
     ))
 
 
-def dry(f, help='Enable/disable actions taken by the script'):
+def dry(f, help='Disable or enable actions taken by the script'):
     """
-    A click decorator that adds a ``--dry/--yes`` flag. It is passed to the
+    A click decorator that adds a ``--dry/--doit`` flag. It is passed to the
     command as ``dry``, and defaults to True.
     """
     return click.option(
-        '--dry/--yes',
+        '--dry/--doit',
         is_flag=True,
         default=True,
         help=help,
     )(f)
-


### PR DESCRIPTION
The --dry/--yes flag conflicted with tag_release's --yes flag, which btw
was broken. Now it's --dry/--doit, and --yes is back to its original
meaning.