### PR TITLE
Add jenkinsfile for openedx-release-ci job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: python
 python:
   - "2.7"
+branches:
+  only:
+    - master
 cache: pip
 install:
   - travis_retry pip install --upgrade pip

--- a/Jenkinsfiles/openedx-release-ci
+++ b/Jenkinsfiles/openedx-release-ci
@@ -1,0 +1,36 @@
+pipeline {
+    agent { label "jenkins-worker" }
+    options {
+        timestamps()
+        timeout(60)
+    }
+    environment {
+        GITHUB_CREDS = credentials('OPENEDX_RELEASE_BOT_CREDENTIALS')
+    }
+    stages {
+        stage('Create virtualenv and install') {
+            steps {
+                sh '''virtualenv openedx_release_venv -q
+                    source openedx_release_venv/bin/activate
+                    make install'''
+            }
+        }
+        stage('Create release branches') {
+            steps {
+            sh '''source openedx_release_venv/bin/activate
+                tag_release --doit --branch open-release/${OPENEDX_RELEASE_NAME} -y --username ${GITHUB_CREDS_USR} --token ${GITHUB_CREDS_PSW}'''
+            }
+        }
+        stage('Delete release branches') {
+            when {
+                expression {
+                    return env.DELETE_OR_KEEP == 'delete';
+                }
+            }
+            steps {
+                sh '''source openedx_release_venv/bin/activate
+                    tag_release --doit -R --branch open-release/${OPENEDX_RELEASE_NAME} -y --username ${GITHUB_CREDS_USR} --token ${GITHUB_CREDS_PSW}'''
+            }
+        }
+    }
+}

--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -590,11 +590,11 @@ def main(hub, ref, use_tag, override_ref, overrides, interactive, quiet,
         if interactive:
             if not click.confirm(u"Is this correct?"):
                 return
-
         result = create_ref_for_repos(ref_info, ref, use_tag=use_tag, dry=dry)
+
         if not quiet:
             if result:
                 click.echo(u"Success!")
             else:
-                click.echo(u"Failed to create refs, but rolled back successfully")
+                raise ValueError(u"Failed to create refs, but rolled back successfully")
         return result


### PR DESCRIPTION
Get the ball rolling on an openedx-release-ci job to test/automate creating releases. So far this will just use the tag_release script to create branches in the necessary branches with a bot I created @openedx-release-bot , and delete them if the DSL parameter tells it to. I also changed one line in the tag_release script to raise an exception rather than just printing to the console, so that the build will fail if that condition is hit.