### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/count_logo_referrers.py
+++ b/count_logo_referrers.py
@@ -20,6 +20,7 @@ Each host shows how many hits there were (56148 in the first line) and
 from how many unique IP addresses (32736).
 
 """
+from __future__ import print_function
 
 import collections
 import glob
@@ -75,8 +76,8 @@ for line in all_gz_lines():
 
 hostinfos = sorted(hosts.iteritems(), key=lambda name_info: name_info[1].hits, reverse=True)
 for name, info in hostinfos:
-    print "{:>60}: {}, {} ips".format(name, info.hits, len(info.ips))
+    print("{:>60}: {}, {} ips".format(name, info.hits, len(info.ips)))
 
-print "-" * 50
+print("-" * 50)
 for uri, count in uris.most_common():
-    print "{:<50}: {}".format(uri, count)
+    print("{:<50}: {}".format(uri, count))

--- a/edx_repo_tools/oep2/checks/check_oep10.py
+++ b/edx_repo_tools/oep2/checks/check_oep10.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ast
 import logging
 
@@ -66,7 +67,7 @@ def uses_pbr(parsed_setup_py):
 
 def parsed_requirements_txt(requirements_txt):
     if not requirements_txt.exists():
-        print "not exists"
+        print("not exists")
         return
 
     for line in requirements_txt.lines():
@@ -151,15 +152,15 @@ class OEP10(object):
 
         is_django_application = manage_py.exists()
 
-        print is_django_application
-        print setup_py.exists()
+        print(is_django_application)
+        print(setup_py.exists())
 
         if requirements_base_txt.exists():
             requirements_file = reqirements_base_txt
         else:
             requirements_file = requirements_txt
 
-        print requirements_file.exists()
+        print(requirements_file.exists())
 
         if not is_django_application and setup_py.exists():
             parsed_setup_py = ast.parse(setup_py.bytes(), 'setup.py')

--- a/edx_repo_tools/oep2/report/plugin.py
+++ b/edx_repo_tools/oep2/report/plugin.py
@@ -263,7 +263,7 @@ class Oep2ReportPlugin(object):
             "<tr><th>{}</th>{}</tr>".format(
                 repo,
                 "\n".join(format_report(tests.get(test_key), test_key) for test_key in test_order)
-            ) for repo, tests in sorted(self.results.items(), key=lambda (repo, _): repo.lower())
+            ) for repo, tests in sorted(self.results.items(), key=lambda repo__: repo__[0].lower())
         )
 
         with open('oep2.report.html', 'w') as report:

--- a/load_logo_referrers_summary.py
+++ b/load_logo_referrers_summary.py
@@ -24,6 +24,7 @@ Suggested queries:
 select domain, min(date) from access_log_aggregate where domain not like '%.amazonaws.com' and domain not rlike '([[:digit:]]+\\.){3}[[:digit:]]+:?' and domain not rlike ':[[:digit:]]+' and domain not like '%.edx.org' group by domain order by min(date);
 
 """
+from __future__ import print_function
 
 import collections
 import glob
@@ -93,7 +94,7 @@ def add_to_filename_log(cur, log_name):
     cur.execute(insert_into_file_hist, [log_name])
 
 def process_log_file(cur, gz_file, log_name):
-    print "Processing %s ..." % log_name
+    print("Processing %s ..." % log_name)
     line_counter = {}
     for line in gz_file:
         if line.startswith('#'):
@@ -102,7 +103,7 @@ def process_log_file(cur, gz_file, log_name):
         logline = LogLine(line)
         if logline.uri.startswith("/openedx-logos"):
             line_key = "|".join((logline.host, logline.date, log_name))
-            if line_counter.has_key(line_key):
+            if line_key in line_counter:
                 line_counter[line_key] += 1
             else:
                 line_counter[line_key] = 1
@@ -112,16 +113,16 @@ def process_log_file(cur, gz_file, log_name):
         line_count = line_counter[aggregate_line_key]
         insert_stmt = "INSERT INTO access_log_aggregate (domain, date, filename, count) values (%s, %s, %s, %s)"
         cur.execute(insert_stmt,  (host, date, log_name, line_count))
-        print "Inserted %d rows" % cur.rowcount
+        print("Inserted %d rows" % cur.rowcount)
     db.commit()
 
 cur = db.cursor()
 
 for gz_name in glob.glob("*.gz"):
-    print gz_name
+    print(gz_name)
     with gzip.open(gz_name) as gz:
         if(not is_in_filename_log(cur, gz_name)):
-            print "%s not found, adding" % gz_name
+            print("%s not found, adding" % gz_name)
             add_to_filename_log(cur, gz_name)
             process_log_file(cur, gz, gz_name)
 db.close()

--- a/non-edx-people.py
+++ b/non-edx-people.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Produce a list of the emails of all non-edX people in people.yaml"""
+from __future__ import print_function
 
 import yaml
 
@@ -8,4 +9,4 @@ with open("people.yaml") as people_yaml:
 non_edx = (e for e in people.itervalues() if e.get('institution') != 'edX')
 email_ok = (e for e in non_edx if e.get('email_ok', True))
 emails = (e.get('email', '').strip() for e in email_ok)
-print ",\n".join(em for em in emails if em)
+print(",\n".join(em for em in emails if em))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.