### PR TITLE
Inverted condition of render function filteration

### DIFF
--- a/django2_codemods/widget_add_renderer_mod.py
+++ b/django2_codemods/widget_add_renderer_mod.py
@@ -8,8 +8,8 @@ from fissix.pytree import Leaf
 
 def render_has_no_renderer(node: LN, capture: Capture, filename: Filename) -> bool:
 
-    if 'function_call' in capture:
-        return False  # This is a function call, no need to add argument
+    if 'function_def' not in capture:
+        return False  # This is not a function definition, no need to add argument
 
     arguments = capture.get("function_arguments")[0].children
 


### PR DESCRIPTION
I inverted the condition because function imports was causing problems alongside function call, so instead of adding a new condition, I inverted condition that it should only work on function definitions.