### PR TITLE
Added travis modernizer to update travis configurations

### DIFF
--- a/django3_codemods/config_tools/travis_modernizer.py
+++ b/django3_codemods/config_tools/travis_modernizer.py
@@ -1,0 +1,94 @@
+import collections
+from copy import deepcopy
+import re
+import sys
+import yaml
+
+MAPPING_TAG = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
+
+
+def dict_representer(dumper, data):
+    return dumper.represent_mapping(MAPPING_TAG, data.items())
+
+
+def dict_constructor(loader, node):
+    return collections.OrderedDict(loader.construct_pairs(node))
+
+
+def setup_ordered_yaml_parser():
+    """
+    Default yaml parser does not maintains the order of elements.
+    This function overrides the default mapping to maintain
+    the original order of elements in the travis file.
+    """
+    yaml.add_representer(collections.OrderedDict, dict_representer)
+    yaml.add_constructor(MAPPING_TAG, dict_constructor)
+
+
+class TravisModernizer:
+    def __init__(self, file_path):
+        setup_ordered_yaml_parser()
+        self.file_path = file_path
+        self.travis_dict = None
+        self.DJANGO_PATTERN = re.compile("django[0-2][0-1]")  # creates regex to match django111, django20 && django21
+
+    def remove_django_envs(self):
+        with open(self.file_path, 'r') as file:
+            self.travis_dict = yaml.load(file, Loader=yaml.FullLoader)
+            if 'matrix' in self.travis_dict.keys():
+                env_list = self.travis_dict['matrix']['include']
+                updated_list = [
+                    env for env in env_list if not self.DJANGO_PATTERN.search(env['env'])
+                ]
+                self.travis_dict['matrix']['include'] = updated_list
+            if 'env' in self.travis_dict.keys():
+                env_list = self.travis_dict['env']
+                updated_list = [
+                    env for env in env_list if not self.DJANGO_PATTERN.search(env)
+                ]
+                self.travis_dict['env'] = updated_list
+            return self.travis_dict
+
+    def update_python_version(self):
+        """
+        Add py38, remove py36 if present.
+        """
+        with open(self.file_path, 'r') as file:
+            self.travis_dict = yaml.load(file, Loader=yaml.FullLoader)
+            if 'python' in self.travis_dict.keys():
+                self.travis_dict['python'].append('3.8')
+                if '3.6' in self.travis_dict['python']:
+                    self.travis_dict['python'].remove('3.6')
+            if 'matrix' in self.travis_dict.keys():
+                env_list = self.travis_dict['matrix']['include']
+                # remove python 3.6 if present
+                allowed_envs = []
+                for env in env_list:
+                    if 'python' in env.keys():
+                        if env['python'] != 3.6:
+                            allowed_envs.append(deepcopy(env))
+                # add python 3.8 in env_list
+                new_python_envs = []
+                for env in allowed_envs:
+                    if 'python' in env.keys():
+                        #  copy whole element and add it in env_list with python3.8 version.
+                        env_copy = deepcopy(env)
+                        env_copy['python'] = '3.8'
+                        new_python_envs.append(deepcopy(env_copy))
+                self.travis_dict['matrix']['include'] = allowed_envs + new_python_envs
+            return self.travis_dict
+
+    def write_updated_data(self):
+        with open(self.file_path, 'w') as file:
+            yaml.dump(self.travis_dict, file, default_flow_style=False, sort_keys=True)
+
+    def modernize(self):
+        self.update_python_version()
+        self.write_updated_data()
+        self.remove_django_envs()
+        self.write_updated_data()
+
+
+if __name__ == '__main__':
+    modernizer = TravisModernizer(file_path=sys.argv[1])
+    modernizer.modernize()

--- a/tests/test_travis.yml
+++ b/tests/test_travis.yml
@@ -1,0 +1,27 @@
+language: python
+
+python:
+  - "3.5"
+  - "3.6"
+
+branches:
+  only:
+    - master
+
+sudo: required
+
+cache:
+  - pip
+
+env:
+  - TOXENV=django111
+  - TOXENV=django20
+  - TOXENV=django21
+  - TOXENV=django22
+  - TOXENV=quality-and-translations
+  - TOXENV=acceptance-tests
+
+after_success:
+    - pip install --upgrade codecov
+    - make exec-coverage
+    - codecov

--- a/tests/test_travis_2.yml
+++ b/tests/test_travis_2.yml
@@ -1,0 +1,45 @@
+language: python
+
+branches:
+  only:
+    - master
+
+sudo: required
+
+cache:
+  - pip
+
+install:
+      pip install tox
+
+matrix:
+  include:
+    - python: 3.6
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=quality-and-js
+        TARGETS="check_translations_up_to_date clean_static quality"
+    - python: 3.8
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=quality-and-js
+        TARGETS="check_translations_up_to_date clean_static quality"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=quality-and-js
+        TARGETS="check_translations_up_to_date clean_static quality"
+    - python: 3.5
+      env:
+        TESTNAME=quality-and-js
+        TARGETS="check_translations_up_to_date clean_static quality"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django22
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+
+after_success:
+  - pip install -U codecov
+  - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_coverage.sh
+  - codecov

--- a/tests/test_travis_modernizer.py
+++ b/tests/test_travis_modernizer.py
@@ -1,0 +1,64 @@
+import os
+import re
+import shutil
+import uuid
+from django3_codemods.config_tools.travis_modernizer import TravisModernizer
+from unittest import TestCase
+
+
+class TravisModernizerTest(TestCase):
+
+    def setUp(self):
+        self.test_file1 = self._setup_local_copy("test_travis.yml")
+        self.test_file2 = self._setup_local_copy("test_travis_2.yml")
+        self.DJANGO_PATTERN = "django[0-2][0-1]"  # creates regex to match django111, django20 && django21
+
+    @staticmethod
+    def _setup_local_copy(file_name):
+        current_directory = os.path.dirname(__file__)
+        temp_file = os.path.join(current_directory, str(uuid.uuid4()) + ".yml")
+        local_file = os.path.join(current_directory, file_name)
+        shutil.copy2(local_file, temp_file)
+        return temp_file
+
+    @staticmethod
+    def _get_parser(file_path):
+        parser = TravisModernizer(file_path=file_path)
+        return parser
+
+    def _assert_django_versions_removed(self, test_file):
+        parser = self._get_parser(test_file)
+        parsed_data = parser.remove_django_envs()
+        if 'matrix' in parsed_data.keys():
+            env_list = parsed_data['matrix']['include']
+            for env in env_list:
+                self.assertNotRegex(self.DJANGO_PATTERN, env['env'])
+        if 'env' in parsed_data.keys():
+            env_list = parsed_data['env']
+            for env in env_list:
+                self.assertNotRegex(self.DJANGO_PATTERN, env)
+
+    def _assert_python_versions_updated(self, test_file):
+        parser = self._get_parser(test_file)
+        parsed_data = parser.update_python_version()
+        if 'python' in parsed_data.keys():
+            self.assertIn('3.8', parsed_data['python'])
+            self.assertNotIn('3.6', parsed_data['python'])
+        if 'matrix' in parsed_data.keys():
+            env_list = parsed_data['matrix']['include']
+            python_versions = set([env['python'] for env in env_list])
+            self.assertIn('3.8', python_versions)
+            self.assertNotIn('3.6', python_versions)
+
+    def test_django_versions_removed(self):
+        self._assert_django_versions_removed(self.test_file1)
+        self._assert_django_versions_removed(self.test_file2)
+
+    def test_python_version_added(self):
+        self._assert_python_versions_updated(self.test_file1)
+        self._assert_python_versions_updated(self.test_file2)
+
+    def tearDown(self):
+        os.remove(self.test_file1)
+        os.remove(self.test_file2)
+


### PR DESCRIPTION
**Relevant Issue:** [BOM-1507](https://openedx.atlassian.net/browse/BOM-1507)

### Description
Travis Modernizer script performs the following operations on a given `Travis` file:
- Remove Django versions `1.11`, `2.0` && `2.1`
- Remove Python `3.6` from test envs.
- Add Python `3.8` to test envs.