### PR TITLE
[BD] Fix oep-18 check

### DIFF
--- a/ownership_tools/get_repos.py
+++ b/ownership_tools/get_repos.py
@@ -190,7 +190,7 @@ def might_be_oep18_compliant(repo):
     try:
         makefile_contentfile= repo.get_contents("Makefile")
         makefile_content_file_string = makefile_contentfile.decoded_content.decode('utf-8')
-        search_output = re.search("^upgrade:", makefile_content_file_string)
+        search_output = re.search("^upgrade:", makefile_content_file_string, re.MULTILINE)
         if search_output:
             return (True, "upgrade target exists in Makefile")
         return (False, "upgrade target does not exist in makefile")


### PR DESCRIPTION
Fix function that checks if a repo is oep 18 compliant.

Basically it is using a regex to check if the Makefile has a line that starts with `^upgrade:`, but it was failing most of the times becuase the re.MULTILINE option was not enabled.

## Reviewers

- [ ] @jmbowman 
- [ ] Ready for edX review