### PR TITLE
[BD] Fix parsing of version of python

### DIFF
--- a/ownership_tools/get_repos.py
+++ b/ownership_tools/get_repos.py
@@ -215,8 +215,10 @@ def filter_valid_pythons(version_list):
             yield version
 
         elif type(version) == str:
-            if float(version.rstrip('-dev')) >= 3.5:
-                yield version
+            parsed_version = re.search("^\d+(\.\d+)?", version)
+            if parsed_version:
+                if float(parsed_version.group(0)) >= 3.5:
+                    yield version
 
 def might_be_oep7_compliant(repo):
     """


### PR DESCRIPTION
Currently it is failing when the version has this format X.X.X, for instance:

https://github.com/edx/registrar/blob/6be44b5871808b6ba4aab27299ce2480cf22fcc5/.travis.yml#L3

The error is ValueError: could not convert string to float: '3.5.2'

## Reviewers
- [ ] @jmbowman 
- [ ] Ready for edX review.