### PR TITLE
Update Elasticsearch 7 info for the 7.8 release being targeted

### DIFF
--- a/barcalendar.py
+++ b/barcalendar.py
@@ -412,7 +412,7 @@ es_releases = [
     ('2.4', 2016, 8, 2018, 2),
     ('5.6', 2017, 9, 2019, 3),
     ('6.8', 2019, 5, 2020, 11),
-    ('7.3', 2019, 8, 2021, 1),
+    ('7.8', 2020, 6, 2021, 12),
 ]
 for name, syear, smonth, eyear, emonth in es_releases:
     cal.bar(f"elasticsearch {name}", start=(syear, smonth), end=(eyear, emonth), color="#4595ba", current=(name==CURRENT["elasticsearch"]))


### PR DESCRIPTION
We're now targeting an upgrade to Elasticsearch 7.8, not 7.3.  Update the relevant support window bar accordingly.