### PR TITLE
Fix Github Actions modernizer

### DIFF
--- a/django3_codemods/config_tools/github_actions_modernizer.py
+++ b/django3_codemods/config_tools/github_actions_modernizer.py
@@ -19,8 +19,15 @@ class GithubCIModernizer(YamlLoader):
         self.yml_instance.indent(mapping=2, sequence=2, offset=0)
 
     def _update_matrix(self):
-        matrix_elements = deepcopy(self.elements['jobs']['run_tests']['strategy']['matrix'])
+
         python_versions = list()
+        matrix_elements = dict()
+        section_key = None
+
+        for key in ['build', 'tests', 'run_tests', 'run_quality']:
+            if key in self.elements['jobs']:
+                section_key = key
+                matrix_elements = deepcopy(self.elements['jobs'][section_key]['strategy']['matrix'])
 
         for key, value in matrix_elements.items():
             if key == 'python-version':
@@ -33,11 +40,11 @@ class GithubCIModernizer(YamlLoader):
                         without_python35.append(item)
 
                 if len(without_python35):
-                    self.elements['jobs']['run_tests']['strategy']['matrix'][key] = without_python35
+                    self.elements['jobs'][section_key]['strategy']['matrix'][key] = without_python35
                 else:
-                    del self.elements['jobs']['run_tests']['strategy']['matrix'][key]
+                    del self.elements['jobs'][section_key]['strategy']['matrix'][key]
 
-        self.elements['jobs']['run_tests']['strategy']['matrix']['python-version'] = python_versions
+        self.elements['jobs'][section_key]['strategy']['matrix']['python-version'] = python_versions
 
     def _update_python_versions(self):
         self._update_matrix()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-repo-tools',
-    version='0.2.6',
+    version='0.2.7',
     description="This repo contains a number of tools Open edX uses for working with GitHub repositories.",
     long_description=long_description,
     license='Apache',

--- a/tests/sample_files/sample_ci_file_3.yml
+++ b/tests/sample_files/sample_ci_file_3.yml
@@ -1,0 +1,41 @@
+name: Python CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ['3.5', '3.8']
+        toxenv: ['django22', 'quality', 'docs', 'pii_check']
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install pip
+      run: pip install -r requirements/pip.txt
+
+    - name: Install Dependencies
+      run: pip install -r requirements/ci.txt
+
+    - name: Run Tests
+      env:
+        TOXENV: ${{ matrix.toxenv }}
+      run: tox
+
+    - name: Run Coverage
+      if: matrix.python-version == '3.8' && matrix.toxenv=='django22'
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests
+        fail_ci_if_error: true

--- a/tests/test_actions_modernizer.py
+++ b/tests/test_actions_modernizer.py
@@ -15,6 +15,7 @@ class TestGithubActionsModernizer(TestCase):
     def setUp(self):
         self.test_file1 = self._setup_local_copy("sample_files/sample_ci_file.yml")
         self.test_file2 = self._setup_local_copy("sample_files/sample_ci_file_2.yml")
+        self.test_file3 = self._setup_local_copy("sample_files/sample_ci_file_3.yml")
 
     @staticmethod
     def _setup_local_copy(file_name):
@@ -34,6 +35,13 @@ class TestGithubActionsModernizer(TestCase):
     def test_python_matrix_items(self):
         ci_elements = TestGithubActionsModernizer._get_updated_yaml_elements(self.test_file1)
         python_versions = ci_elements['jobs']['run_tests']['strategy']['matrix']['python-version']
+
+        self.assertIsInstance(python_versions, list)
+        self.assertNotIn('3.5', python_versions)
+
+    def test_python_matrix_items_build_tag(self):
+        ci_elements = TestGithubActionsModernizer._get_updated_yaml_elements(self.test_file3)
+        python_versions = ci_elements['jobs']['build']['strategy']['matrix']['python-version']
 
         self.assertIsInstance(python_versions, list)
         self.assertNotIn('3.5', python_versions)


### PR DESCRIPTION
The cleanup job was failing on multiple repos when ran with this modernizer because we are using inconsistent test sections name in Github ci.yml files, so handled those edge cases.