### PR TITLE
feat: added --ignore-repo flag in get_org_repo_urls command

### DIFF
--- a/edx_repo_tools/dev/get_org_repo_urls.py
+++ b/edx_repo_tools/dev/get_org_repo_urls.py
@@ -27,8 +27,11 @@ from edx_repo_tools.auth import pass_github
 @click.option(
     '--add_archived', is_flag=True, default=False,
     help="Do you want urls for archived repos?")
+@click.option(
+    '--ignore-repo', '-i', multiple=True, default=[],
+    help="If you want to ignore any repo?")
 @pass_github
-def main(hub, forks, org, url_type, output_file, add_archived):
+def main(hub, forks, org, url_type, output_file, add_archived, ignore_repo):
     """
     Used to get the urls for all the repositories in a github organization
     """
@@ -37,6 +40,8 @@ def main(hub, forks, org, url_type, output_file, add_archived):
         if repo.fork and not forks:
             continue
         if repo.archived and not add_archived:
+            continue
+        if repo.name in ignore_repo:
             continue
         if url_type == "ssh":
             repositories.append(repo.ssh_url)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as readme:
 
 setup(
     name='edx-repo-tools',
-    version='0.3.0',
+    version='0.3.1',
     description="This repo contains a number of tools Open edX uses for working with GitHub repositories.",
     long_description=long_description,
     license='Apache',


### PR DESCRIPTION
We want to ignore a repo which was created as part of a test of GitHub's security advisory process, during repo-health-dashboard checks run

Issue: [BOM-2472](https://openedx.atlassian.net/browse/BOM-2472)