### PR TITLE
fix: append instead of overwrite for repos file

### DIFF
--- a/edx_repo_tools/dev/get_org_repo_urls.py
+++ b/edx_repo_tools/dev/get_org_repo_urls.py
@@ -47,6 +47,6 @@ def main(hub, forks, org, url_type, output_file, add_archived, ignore_repo):
             repositories.append(repo.ssh_url)
         else:
             repositories.append(repo.clone_url)
-    with open(output_file, 'w') as filehandle:
+    with open(output_file, 'a') as filehandle:
         for repo_url in repositories:
             filehandle.write('%s\n' % repo_url)


### PR DESCRIPTION
Now that we are collecting repos for multiple organizations we need to append the output to the file instead of overwriting it on existing content.
See https://github.com/edx/jenkins-job-dsl-internal/pull/591